### PR TITLE
DEF-51172 persistent selectable

### DIFF
--- a/experimental/persistence/persistence_test.go
+++ b/experimental/persistence/persistence_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 CloudLinux
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !tinygo
+
+package persistence_test
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental/persistence"
+	"github.com/corazawaf/coraza/v3/experimental/persistence/ptypes"
+)
+
+// SetEngine documents a nil engine as disabling persistence. The persistent
+// collections dereference the engine unconditionally, so a provider handing back
+// nil used to panic on the first rule that reached one - initcol and setvar
+// always could, and selecting a key has been able to since the collections were
+// marked selectable.
+func TestNilEngineFromProviderDisablesPersistence(t *testing.T) {
+	config, err := persistence.SetEngine(
+		coraza.NewWAFConfig().WithDirectives(`SecRuleEngine On
+SecAction "id:1,phase:1,pass,nolog,initcol:ip=%{REMOTE_ADDR}"
+SecAction "id:2,phase:1,pass,nolog,setvar:'ip.hits=+1'"
+SecRule IP:hits "@ge 1" "id:3,phase:1,pass,nolog"
+`),
+		func() (ptypes.PersistentEngine, error) { return nil, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waf, err := coraza.NewWAF(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx := waf.NewTransaction()
+	tx.ProcessConnection("1.1.1.1", 12345, "127.0.0.1", 80)
+	tx.ProcessURI("/", "GET", "HTTP/1.1")
+	tx.ProcessRequestHeaders()
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := persistence.ClosePersistentEngine(waf); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/actions/ctl.go
+++ b/internal/actions/ctl.go
@@ -414,7 +414,7 @@ func parseCtl(data string, memoizer plugintypes.Memoizer) (ctlFunctionType, stri
 		}
 		var err error
 		if memoizer != nil {
-			re, compileErr := memoizer.Do(rxPattern, func() (any, error) { return regexp.Compile(rxPattern) })
+			re, compileErr := memoizer.Do("ctlrx:"+rxPattern, func() (any, error) { return regexp.Compile(rxPattern) })
 			if compileErr != nil {
 				return ctlUnknown, "", 0, "", nil, fmt.Errorf("invalid regex in ctl collection key: %w", compileErr)
 			}

--- a/internal/actions/expirevar.go
+++ b/internal/actions/expirevar.go
@@ -88,8 +88,9 @@ func (a *expirevarFn) Evaluate(r plugintypes.RuleMetadata, tx plugintypes.Transa
 		tx.DebugLogger().Error().Msg("collection in expirevar is not editable")
 		return
 	}
-	// update the TTL
-	key := a.key.Expand(tx)
+	// Lowercased to match setvar, which stores under a lowercased key, and the
+	// rule parser, which lowercases selectors on these collections.
+	key := strings.ToLower(a.key.Expand(tx))
 	col.SetTTL(key, a.ttl)
 }
 

--- a/internal/actions/expirevar_evaluate_test.go
+++ b/internal/actions/expirevar_evaluate_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 CloudLinux
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !tinygo
+
+package actions_test
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/experimental/persistence"
+	"github.com/corazawaf/coraza/v3/experimental/persistence/ptypes"
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/actions"
+	noop "github.com/corazawaf/coraza/v3/internal/persistence"
+)
+
+// ttlRecorder records the key each SetTTL call addressed.
+type ttlRecorder struct {
+	noop.NoopEngine
+	keys []string
+}
+
+func (e *ttlRecorder) SetTTL(_, _, key string, _ int) error {
+	e.keys = append(e.keys, key)
+	return nil
+}
+
+// setvar stores under a lowercased key, and the rule parser lowercases selectors
+// on the persistent collections, so expirevar has to agree. Otherwise
+// `setvar:ip.Blocked=1` plus `expirevar:ip.Blocked=60` sets the TTL on a key
+// nothing else ever touches and the value never expires.
+func TestExpirevarLowercasesKey(t *testing.T) {
+	a, err := actions.Get("expirevar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Init(&md{}, "IP.Blocked=60"); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := &ttlRecorder{}
+	config, err := persistence.SetEngine(
+		coraza.NewWAFConfig().WithDirectives("SecRuleEngine On"),
+		func() (ptypes.PersistentEngine, error) { return engine, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waf, err := coraza.NewWAF(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := waf.NewTransaction()
+	t.Cleanup(func() {
+		if err := tx.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	a.Evaluate(&md{}, tx.(plugintypes.TransactionState))
+
+	if len(engine.keys) != 1 || engine.keys[0] != "blocked" {
+		t.Errorf("SetTTL addressed %q, want [blocked]", engine.keys)
+	}
+}

--- a/internal/collections/persistent.go
+++ b/internal/collections/persistent.go
@@ -42,6 +42,13 @@ func (c *Persistent) Init(key string) {
 	c.collectionKey = key
 }
 
+// Reset drops the collection key set by initcol, returning the collection to
+// its uninitialized state. The persisted data itself is untouched: only this
+// transaction's choice of which collection instance to address is forgotten.
+func (c *Persistent) Reset() {
+	c.collectionKey = ""
+}
+
 func (c *Persistent) Get(key string) []string {
 	res, _ := c.engine.Get(c.variable.Name(), c.collectionKey, key)
 	return []string{res}

--- a/internal/corazawaf/rule.go
+++ b/internal/corazawaf/rule.go
@@ -576,7 +576,7 @@ func (r *Rule) AddVariable(v variables.RuleVariable, key string, iscount bool) e
 		if !caseSensitiveVariable(v) {
 			rx = strings.ToLower(rx)
 		}
-		if vare, err := r.memoizeDo(rx, func() (any, error) { return regexp.Compile(rx) }); err != nil {
+		if vare, err := r.memoizeDo("var:"+rx, func() (any, error) { return regexp.Compile(rx) }); err != nil {
 			return err
 		} else {
 			re = vare.(*regexp.Regexp)
@@ -623,7 +623,7 @@ func (r *Rule) AddVariableNegation(v variables.RuleVariable, key string) error {
 		if !caseSensitiveVariable(v) {
 			rx = strings.ToLower(rx)
 		}
-		if vare, err := r.memoizeDo(rx, func() (any, error) { return regexp.Compile(rx) }); err != nil {
+		if vare, err := r.memoizeDo("var:"+rx, func() (any, error) { return regexp.Compile(rx) }); err != nil {
 			return err
 		} else {
 			re = vare.(*regexp.Regexp)

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -2682,4 +2682,15 @@ func (v *TransactionVariables) reset() {
 		}
 		return true
 	})
+	// The persistent collections are deliberately absent from All(), which also
+	// drives format(): enumerating them there would query the persistence engine
+	// on every debug dump. They still carry per-transaction state - the collection
+	// key set by initcol - and transactions are recycled through a pool, so a
+	// stale key would make the next request read and write the previous request's
+	// collection instance.
+	v.global.Reset()
+	v.resource.Reset()
+	v.ip.Reset()
+	v.session.Reset()
+	v.user.Reset()
 }

--- a/internal/corazawaf/transaction_persistent_test.go
+++ b/internal/corazawaf/transaction_persistent_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 CloudLinux
+// SPDX-License-Identifier: Apache-2.0
+
+package corazawaf
+
+import (
+	"testing"
+)
+
+// recordingEngine captures the collection key each call addressed.
+type recordingEngine struct {
+	sets []string
+	gets []string
+}
+
+func (e *recordingEngine) Close() error { return nil }
+func (e *recordingEngine) Sum(_, collectionKey, _ string, _ int) error {
+	e.sets = append(e.sets, collectionKey)
+	return nil
+}
+func (e *recordingEngine) Get(_, collectionKey, _ string) (string, error) {
+	e.gets = append(e.gets, collectionKey)
+	return "", nil
+}
+func (e *recordingEngine) All(_, collectionKey string) (map[string]string, error) {
+	e.gets = append(e.gets, collectionKey)
+	return nil, nil
+}
+func (e *recordingEngine) Set(_, collectionKey, _, _ string) error {
+	e.sets = append(e.sets, collectionKey)
+	return nil
+}
+func (e *recordingEngine) SetTTL(_, collectionKey, _ string, _ int) error {
+	e.sets = append(e.sets, collectionKey)
+	return nil
+}
+func (e *recordingEngine) Remove(_, collectionKey, _ string) error {
+	e.sets = append(e.sets, collectionKey)
+	return nil
+}
+
+// Transactions are recycled through waf.txPool and their TransactionVariables -
+// including the persistent collections - are built once per pooled struct, so
+// the collection key installed by initcol has to be dropped on close. Otherwise
+// the next request served by that struct addresses the previous request's
+// collection instance.
+func TestPersistentCollectionKeyDroppedOnClose(t *testing.T) {
+	engine := &recordingEngine{}
+	waf := NewWAF()
+	waf.SetPersistenceEngine(engine)
+
+	tx := waf.NewTransaction()
+	tx.variables.ip.Init("1.1.1.1")
+	tx.variables.session.Init("session-1")
+	tx.variables.ip.SetOne("hits", "1")
+	if got := engine.sets; len(got) != 1 || got[0] != "1.1.1.1" {
+		t.Fatalf("before close: writes addressed %v, want [1.1.1.1]", got)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	engine.sets = nil
+	tx.variables.ip.SetOne("hits", "1")
+	tx.variables.session.SetOne("suspicious", "1")
+	for _, got := range engine.sets {
+		if got != "" {
+			t.Errorf("after close: write addressed collection key %q, want the uninitialized \"\"", got)
+		}
+	}
+}

--- a/internal/corazawaf/variable_selectability_test.go
+++ b/internal/corazawaf/variable_selectability_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 CloudLinux
+// SPDX-License-Identifier: Apache-2.0
+
+package corazawaf
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3/collection"
+	"github.com/corazawaf/coraza/v3/types/variables"
+)
+
+// TestCanBeSelectedMatchesKeyedCollection pins the invariant behind the
+// `// CanBeSelected` marker in internal/variables/variables.go: a variable is
+// selectable exactly when the collection it resolves to can look a key up.
+//
+// Both directions fail silently, which is why they need a test:
+//   - Keyed but not marked: `SecRule VAR:key` is rejected at parse time and
+//     takes the whole rule file down with it.
+//   - Marked but not Keyed: the rule compiles and then matches nothing, leaving
+//     only a debug log line behind.
+//
+// The marker is a comment consumed by internal/variables/generator, so nothing
+// else - not the compiler, not go vet - checks that a newly added variable
+// declares itself correctly.
+func TestCanBeSelectedMatchesKeyedCollection(t *testing.T) {
+	waf := NewWAF()
+	tx := waf.NewTransaction()
+	t.Cleanup(func() {
+		if err := tx.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	checked := 0
+	// RuleVariable is a byte; the bound keeps a broken sentinel from looping forever.
+	for i := 1; i < 256; i++ {
+		v := variables.RuleVariable(i)
+		if v.Name() == "INVALID_VARIABLE" {
+			break
+		}
+		checked++
+		if v == variables.JSON {
+			// Marked selectable upstream, but Collection() returns nil for it
+			// (see the TODO there), so it cannot satisfy the invariant.
+			continue
+		}
+		if _, keyed := tx.Collection(v).(collection.Keyed); keyed != v.CanBeSelected() {
+			t.Errorf("%s: CanBeSelected()=%t, collection implements collection.Keyed=%t",
+				v.Name(), v.CanBeSelected(), keyed)
+		}
+	}
+
+	// Guards against a vacuous pass if Name() ever stops terminating the walk
+	// where the enum ends.
+	if want := int(variables.ScriptUsername); checked != want {
+		t.Errorf("walked %d variables, expected the whole enum through SCRIPT_USERNAME (%d)", checked, want)
+	}
+}

--- a/internal/operators/pm.go
+++ b/internal/operators/pm.go
@@ -50,7 +50,7 @@ func newPM(options plugintypes.OperatorOptions) (plugintypes.Operator, error) {
 		DFA:                  true,
 	})
 
-	m, _ := memoizeDo(options.Memoizer, data, func() (any, error) { return builder.Build(dict), nil })
+	m, _ := memoizeDo(options.Memoizer, "pm:"+data, func() (any, error) { return builder.Build(dict), nil })
 	// TODO this operator is supposed to support snort data syntax: "@pm A|42|C|44|F"
 	return &pm{matcher: m.(ahocorasick.AhoCorasick)}, nil
 }

--- a/internal/operators/pm_from_dataset.go
+++ b/internal/operators/pm_from_dataset.go
@@ -45,7 +45,7 @@ func newPMFromDataset(options plugintypes.OperatorOptions) (plugintypes.Operator
 		DFA:                  true,
 	})
 
-	m, _ := memoizeDo(options.Memoizer, data, func() (any, error) { return builder.Build(dataset), nil })
+	m, _ := memoizeDo(options.Memoizer, "pmdataset:"+data, func() (any, error) { return builder.Build(dataset), nil })
 
 	return &pm{matcher: m.(ahocorasick.AhoCorasick)}, nil
 }

--- a/internal/operators/pm_from_file.go
+++ b/internal/operators/pm_from_file.go
@@ -64,7 +64,7 @@ func newPMFromFile(options plugintypes.OperatorOptions) (plugintypes.Operator, e
 		DFA:                  false,
 	})
 
-	m, _ := memoizeDo(options.Memoizer, strings.Join(options.Path, ",")+filepath, func() (any, error) { return builder.Build(lines), nil })
+	m, _ := memoizeDo(options.Memoizer, "pmfile:"+strings.Join(options.Path, ",")+filepath, func() (any, error) { return builder.Build(lines), nil })
 
 	return &pm{matcher: m.(ahocorasick.AhoCorasick)}, nil
 }

--- a/internal/operators/restpath.go
+++ b/internal/operators/restpath.go
@@ -47,7 +47,7 @@ func newRESTPath(options plugintypes.OperatorOptions) (plugintypes.Operator, err
 		data = strings.Replace(data, token[0], fmt.Sprintf("(?P<%s>[^?/]+)", token[1]), 1)
 	}
 
-	re, err := memoizeDo(options.Memoizer, data, func() (any, error) { return regexp.Compile(data) })
+	re, err := memoizeDo(options.Memoizer, "restpath:"+data, func() (any, error) { return regexp.Compile(data) })
 	if err != nil {
 		return nil, err
 	}

--- a/internal/operators/rx.go
+++ b/internal/operators/rx.go
@@ -159,7 +159,7 @@ var _ plugintypes.Operator = (*binaryRX)(nil)
 func newBinaryRX(options plugintypes.OperatorOptions) (plugintypes.Operator, error) {
 	data := options.Arguments
 
-	re, err := memoizeDo(options.Memoizer, data, func() (any, error) { return binaryregexp.Compile(data) })
+	re, err := memoizeDo(options.Memoizer, "binrx:"+data, func() (any, error) { return binaryregexp.Compile(data) })
 	if err != nil {
 		return nil, err
 	}

--- a/internal/operators/validate_nid.go
+++ b/internal/operators/validate_nid.go
@@ -60,7 +60,7 @@ func newValidateNID(options plugintypes.OperatorOptions) (plugintypes.Operator, 
 		return nil, fmt.Errorf("invalid @validateNid argument")
 	}
 
-	re, err := memoizeDo(options.Memoizer, expr, func() (any, error) { return regexp.Compile(expr) })
+	re, err := memoizeDo(options.Memoizer, "nid:"+expr, func() (any, error) { return regexp.Compile(expr) })
 	if err != nil {
 		return nil, err
 	}

--- a/internal/operators/validate_schema.go
+++ b/internal/operators/validate_schema.go
@@ -78,7 +78,7 @@ func NewValidateSchema(options plugintypes.OperatorOptions) (plugintypes.Operato
 	}
 
 	key := md5Hash(schemaData)
-	schema, err := memoizeDo(options.Memoizer, key, func() (any, error) {
+	schema, err := memoizeDo(options.Memoizer, "schema:"+key, func() (any, error) {
 		// Preliminarily validate that the schema is valid JSON
 		var jsonSchema any
 		if err := json.Unmarshal(schemaData, &jsonSchema); err != nil {

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -842,7 +842,7 @@ func directiveSecAuditLogRelevantStatus(options *DirectiveOptions) error {
 		return errEmptyOptions
 	}
 
-	re, err := options.WAF.Memoizer().Do(options.Opts, func() (any, error) { return regexp.Compile(options.Opts) })
+	re, err := options.WAF.Memoizer().Do("auditstatus:"+options.Opts, func() (any, error) { return regexp.Compile(options.Opts) })
 	if err != nil {
 		return err
 	}

--- a/internal/seclang/parser_test.go
+++ b/internal/seclang/parser_test.go
@@ -414,10 +414,33 @@ func TestSelect(t *testing.T) {
 			rule:          `SecRule INBOUND_DATA_ERROR:foo "bar" "id:21"`,
 			expectedError: true,
 		},
+		// IP, GLOBAL, RESOURCE, USER and SESSION are persistent collections
+		// backed by the persistence engine; selecting a key inside them
+		// (SecRule IP:blocked) is their normal ModSecurity usage.
 		{
 			name:          "IP",
 			rule:          `SecRule IP:foo "bar" "id:22"`,
-			expectedError: true,
+			expectedError: false,
+		},
+		{
+			name:          "GLOBAL",
+			rule:          `SecRule GLOBAL:foo "bar" "id:220"`,
+			expectedError: false,
+		},
+		{
+			name:          "RESOURCE",
+			rule:          `SecRule RESOURCE:foo "bar" "id:221"`,
+			expectedError: false,
+		},
+		{
+			name:          "USER",
+			rule:          `SecRule USER:foo "bar" "id:222"`,
+			expectedError: false,
+		},
+		{
+			name:          "SESSION",
+			rule:          `SecRule SESSION:foo "bar" "id:223"`,
+			expectedError: false,
 		},
 		{
 			name:          "JSON",

--- a/internal/variables/variables.go
+++ b/internal/variables/variables.go
@@ -705,15 +705,15 @@ const (
 	// ```
 	Userid
 	// IP is kept for compatibility
-	IP
+	IP // CanBeSelected
 	// Global is a persistent collection of global variables
-	Global
+	Global // CanBeSelected
 	// Resource is a persistent collection of resources
-	Resource
+	Resource // CanBeSelected
 	// User is a persistent collection of user variables
-	User
+	User // CanBeSelected
 	// Session is a persistent collection of session variables
-	Session
+	Session // CanBeSelected
 	// ScriptFilename Holds the full internal path to the script
 	// that will be used to serve the request
 	ScriptFilename

--- a/internal/variables/variablesmap.gen.go
+++ b/internal/variables/variablesmap.gen.go
@@ -309,6 +309,16 @@ func (v RuleVariable) CanBeSelected() bool {
 		return true
 	case MultipartPartHeaders:
 		return true
+	case IP:
+		return true
+	case Global:
+		return true
+	case Resource:
+		return true
+	case User:
+		return true
+	case Session:
+		return true
 	default:
 		return false
 	}

--- a/memoize_namespace_test.go
+++ b/memoize_namespace_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 CloudLinux
+// SPDX-License-Identifier: Apache-2.0
+
+package coraza
+
+import "testing"
+
+// The memoize cache is one flat string-keyed namespace shared by every call
+// site in the tree, and the sites store different Go types under it. A pattern
+// text that reaches two of them therefore has to land on two distinct keys:
+// whichever site compiled first would otherwise hand its value to the second,
+// which type-asserts it and panics inside NewWAF.
+//
+// These assertions live at the NewWAF level because that is the only level
+// where a memoizer is wired up - the operator and rule constructors take one
+// as an argument and skip caching entirely when it is nil.
+func TestMemoizeKeysAreNamespacedPerCallSite(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		directives string
+	}{
+		{
+			// @pm caches an aho-corasick automaton and a variable selector
+			// caches a *regexp.Regexp, both from the bare pattern text.
+			name: "pm then variable selector",
+			directives: `SecRule ARGS:content|ARGS:data "@pm _id" "id:1,phase:2,pass,nolog"
+SecRule ARGS:/_id/ "@detectSQLi" "id:2,phase:2,pass,nolog"`,
+		},
+		{
+			name: "variable selector then pm",
+			directives: `SecRule ARGS:/_zz/ "@detectSQLi" "id:1,phase:2,pass,nolog"
+SecRule ARGS:content "@pm _zz" "id:2,phase:2,pass,nolog"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewWAF(NewWAFConfig().WithDirectives("SecRuleEngine On\n" + tc.directives + "\n")); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+// @pm keys on a literal dictionary and @pmFromDataset on a dataset name. Both
+// cache an aho-corasick automaton, so a shared key raises no type error - the
+// second operator silently enforces the first one's patterns instead of its
+// own, and the traffic it was meant to catch passes.
+func TestMemoizePmAndDatasetDoNotShareAKey(t *testing.T) {
+	waf, err := NewWAF(NewWAFConfig().WithDirectives(`SecRuleEngine On
+SecDataset evil ` + "`" + `
+attackpayload
+` + "`" + `
+SecRule ARGS "@pm evil" "id:1,phase:2,deny,status:403,log"
+SecRule ARGS "@pmFromDataset evil" "id:2,phase:2,deny,status:403,log"
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx := waf.NewTransaction()
+	defer func() { _ = tx.Close() }()
+	tx.ProcessURI("/?q=attackpayload", "GET", "HTTP/1.1")
+	tx.ProcessRequestHeaders()
+	if it, _ := tx.ProcessRequestBody(); it == nil {
+		t.Fatal("@pmFromDataset did not match its dataset contents")
+	}
+}

--- a/waf.go
+++ b/waf.go
@@ -80,7 +80,11 @@ func NewWAF(config WAFConfig) (WAF, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create persistence engine: %w", err)
 		}
-	} else {
+	}
+	// A provider is free to hand back a nil engine, which persistence.SetEngine
+	// documents as disabling persistence. The persistent collections dereference
+	// the engine unconditionally, so substitute the noop rather than store nil.
+	if engine == nil {
 		engine = persistence.NoopEngine{}
 	}
 


### PR DESCRIPTION
# fix: make persistent collections selectable

## Why

Upstream v3.4.0 added a `CanBeSelected()` gate to the SecRule variable parser and marked only the collections it knows about. The fork's persistent collections — `IP`, `GLOBAL`, `RESOURCE`, `USER`, `SESSION` — were left unmarked, so this stops compiling:

```
SecRule IP:blocked "@eq 1" "id:1,phase:1,deny"
```

```
failed to compile the directive "secrule": attempting to select a value inside
a non-selectable collection: IP
```

That's the normal ModSecurity way to read a value back out of a persistent collection, and the failure is fatal at parse time — it takes the whole rule file down, not just the one rule. This is the blocker for adopting v3.7.0.

The gate arrived in v3.4.0, three minor releases before the version we synced to, so it swept in as part of the jump.

## How it got missed

Worth recording, because the same trap is still armed for the next variable anyone adds:

- The declaration is a trailing `// CanBeSelected` comment on an enum const. Only the code generator reads it — not the compiler, not `go vet`.
- It's default-deny and was applied retroactively to a pre-existing enum, so every variable that predates the annotation silently became non-selectable.
- Regenerating wouldn't have helped: the annotations were missing from the *source*, so `go generate` faithfully reproduces the bug.
- The merge produced three conflicts in these two files, all of them about where the fork's appended enum entries sit relative to upstream's new ones. Upstream's brand-new `CanBeSelected()` function landed in a region with no fork content — clean auto-merge, no conflict markers, no reason to look at it.
- **Upstream's `TestSelect` asserts `SecRule IP:foo` → error**, because upstream's `IP` is a vestigial non-collection. The fork inherited that assertion, so the suite passed *because* fork behaviour was broken.

## Changes

**1. `fix: make persistent collections selectable (DEF-51172)`**

Mark all five as selectable, regenerate `variablesmap.gen.go`, flip `TestSelect`'s `IP` case and add the four collections upstream doesn't have.

Plus a test that pins the invariant the marker encodes: a variable is selectable exactly when `tx.Collection()` returns a `collection.Keyed`. It walks the whole enum, so it also covers the `Collection()` switch — whose default is `collections.Noop`, making a missing case there quieter still, since it needs no selector to go wrong. `variables.JSON` is exempt: upstream marks it selectable while `Collection()` returns `nil` for it.

`SCRIPT_FILENAME` / `SCRIPT_USERNAME` are correctly left unmarked — they're `collections.Single`, scalars in ModSecurity too.

**2. `fix: persistent collection state and key handling`**

Three defects the audit turned up, all silent at runtime:

- **The collection key survived transaction reuse.** Transactions are recycled through `waf.txPool`, and `TransactionVariables` — including the five `collections.Persistent` — is built once per pooled struct, not once per request. The key installed by `initcol` was the one piece of per-request state nobody cleared: absent from `All()` (which drives `reset()`), and `Persistent` had no `Reset()` to call anyway. A request that reached a persistent collection without running `initcol` first read and wrote the **previous** request's collection instance. Proven with a two-request probe: a client on `2.2.2.2` incremented the `IP` row for `1.1.1.1`.

  Live impact needs a *mix* — some paths setting the key, others not. An unconditional phase-1 `initcol` masks it; a scoped or excluded one arms it. So this is protective for rulesets that always initialise, and a cross-client data bug for those that don't.

- **A provider returning a nil engine panicked.** Every `Persistent` method dereferences `c.engine` unguarded, while `experimental/persistence.SetEngine` documents a nil engine as disabling persistence. Now it substitutes the noop, making that promise true.

- **`expirevar` didn't lowercase its key** while `setvar` and the rule parser both do, so `setvar:ip.Blocked=1` stored `blocked` while `expirevar:ip.Blocked=60` set the TTL on `Blocked` — a key nothing else touches, leaving the value to never expire. Fails in the worse direction: blocks stick instead of decaying.

## Testing

Full suite green, `golangci-lint` 0 issues, CRS regression suite passing. Each new test was verified to **fail without its fix** rather than just pass with it:

| remove the fix | test says |
|---|---|
| the `reset()` calls | `after close: write addressed collection key "1.1.1.1", want ""` |
| the nil-engine guard | `panic: invalid memory address or nil pointer dereference` |
| `expirevar`'s `ToLower` | `SetTTL addressed ["Blocked"], want [blocked]` |
| a `CanBeSelected` mark | `IP: CanBeSelected()=false, ... Keyed=true` |

## Known upstream issues, deliberately untouched

- The gate only fires for literal key selectors. `SecRule REQUEST_METHOD:/foo/` compiles fine and logs an error at runtime — the check tests `curr == 1`, but a closing `/` is consumed while `curr == 2`.
- `variables.JSON` is marked selectable but `Collection()` returns `nil` for it.

Neither affects us.