### PR TITLE
Def 51539 body limits and leaks

### DIFF
--- a/coraza.conf-recommended
+++ b/coraza.conf-recommended
@@ -76,6 +76,14 @@ SecRequestBodyLimitAction Reject
 # the request should be rejected (when deployed in blocking mode)
 # or a high-severity alert logged (when deployed in detection-only mode).
 #
+# This rule also fires when a request exceeds SecArgumentsLimit: the arguments
+# left out are the trailing ones, so an attacker who pads a request past the
+# limit chooses what goes uninspected. That case is told apart by
+# REQBODY_ERROR_MSG, logged below, reading "SecArgumentsLimit exceeded". If
+# legitimate traffic trips it, raise SecArgumentsLimit to cover it: that
+# restores full inspection, and the extra cost is paid only by requests that
+# really carry that many arguments.
+#
 SecRule REQBODY_ERROR "!@eq 0" \
     "id:'200002', phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2"
 

--- a/experimental/plugins/plugintypes/bodyprocessor.go
+++ b/experimental/plugins/plugintypes/bodyprocessor.go
@@ -23,6 +23,12 @@ type BodyProcessorOptions struct {
 	DirMode fs.FileMode
 	// RequestBodyRecursionLimit is the maximum recursion level accepted in a body processor
 	RequestBodyRecursionLimit int
+	// ArgumentLimit is the configured SecArgumentsLimit: the number of arguments
+	// an operator allows a body to contribute. A processor charges the
+	// collections it fills against this, and may scale it into a wider budget
+	// for a collection whose members are not arguments; a value <= 0 means
+	// unlimited
+	ArgumentLimit int
 }
 
 // BodyProcessor interface is used to create

--- a/internal/bodyprocessors/argumentslimit_test.go
+++ b/internal/bodyprocessors/argumentslimit_test.go
@@ -1,0 +1,1657 @@
+// Copyright 2026 CloudLinux
+// SPDX-License-Identifier: Apache-2.0
+
+package bodyprocessors_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/bodyprocessors"
+	"github.com/corazawaf/coraza/v3/internal/corazawaf"
+	"github.com/corazawaf/coraza/v3/internal/environment"
+	"github.com/corazawaf/coraza/v3/internal/persistence"
+)
+
+func TestBodyProcessorsArgumentsLimit(t *testing.T) {
+	const members = 10
+
+	processors := []struct {
+		name string
+		mime string
+		body string
+		// total is the number of shared-budget members the body produces across
+		// every collection the processor charges to the argument budget.
+		total int
+		count func(v plugintypes.TransactionVariables) int
+	}{
+		{
+			name: "json",
+			body: func() string {
+				b := strings.Builder{}
+				b.WriteString("{")
+				for i := 0; i < members; i++ {
+					if i > 0 {
+						b.WriteString(",")
+					}
+					fmt.Fprintf(&b, `"k%d":"v"`, i)
+				}
+				b.WriteString("}")
+				return b.String()
+			}(),
+			total: members,
+			count: func(v plugintypes.TransactionVariables) int {
+				return len(v.ArgsPost().FindAll())
+			},
+		},
+		{
+			name: "urlencoded",
+			body: func() string {
+				pairs := make([]string, 0, members)
+				for i := 0; i < members; i++ {
+					pairs = append(pairs, fmt.Sprintf("k%d=v", i))
+				}
+				return strings.Join(pairs, "&")
+			}(),
+			total: members,
+			count: func(v plugintypes.TransactionVariables) int {
+				return len(v.ArgsPost().FindAll())
+			},
+		},
+		{
+			// REQUEST_XML is budgeted at MaxNodesPerArgument members per unit of
+			// the argument limit, so the body carries that many attributes per
+			// unit and the member count is converted back into those units.
+			name: "xml",
+			body: func() string {
+				b := strings.Builder{}
+				b.WriteString("<root>")
+				for i := 0; i < members*bodyprocessors.MaxNodesPerArgument; i++ {
+					fmt.Fprintf(&b, `<e a="v%d"/>`, i)
+				}
+				b.WriteString("</root>")
+				return b.String()
+			}(),
+			total: members,
+			count: func(v plugintypes.TransactionVariables) int {
+				return len(v.RequestXML().FindAll()) / bodyprocessors.MaxNodesPerArgument
+			},
+		},
+		{
+			name: "multipart",
+			mime: "multipart/form-data; boundary=X",
+			body: func() string {
+				b := strings.Builder{}
+				for i := 0; i < members; i++ {
+					fmt.Fprintf(&b, "--X\r\nContent-Disposition: form-data; name=\"k%d\"\r\n\r\nv\r\n", i)
+				}
+				b.WriteString("--X--\r\n")
+				return b.String()
+			}(),
+			// each field part adds one ARGS_POST entry to the shared argument
+			// budget; part headers use a separate budget and are not counted here
+			total: members,
+			count: func(v plugintypes.TransactionVariables) int {
+				return len(v.ArgsPost().FindAll())
+			},
+		},
+	}
+
+	for _, p := range processors {
+		limits := []struct {
+			name    string
+			limit   int
+			wantErr bool
+		}{
+			{name: "over_limit", limit: p.total / 2, wantErr: true},
+			{name: "at_limit", limit: p.total, wantErr: false},
+			{name: "under_limit", limit: p.total * 2, wantErr: false},
+			{name: "unlimited", limit: 0, wantErr: false},
+		}
+		for _, l := range limits {
+			t.Run(p.name+"_"+l.name, func(t *testing.T) {
+				bp, err := bodyprocessors.GetBodyProcessor(p.name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+				err = bp.ProcessRequest(strings.NewReader(p.body), v, plugintypes.BodyProcessorOptions{
+					Mime:                      p.mime,
+					StoragePath:               t.TempDir(),
+					RequestBodyRecursionLimit: 10,
+					ArgumentLimit:             l.limit,
+				})
+				if l.wantErr {
+					if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+						t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+					}
+					if want, have := l.limit, p.count(v); want != have {
+						t.Errorf("truncation must fill the collection to the limit and stop, want %d members, have %d", want, have)
+					}
+				} else {
+					if err != nil {
+						t.Fatalf("unexpected error: %v", err)
+					}
+					if want, have := members, p.count(v); want != have {
+						t.Errorf("unexpected number of members, want %d, have %d", want, have)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestXMLArgumentsLimitSharedBudget asserts that attribute values and element
+// text nodes are charged against one budget: a document made only of element
+// content is bounded, and a document mixing both fills REQUEST_XML to exactly
+// the budget across the two kinds of member together. The budget is the
+// argument limit scaled by MaxNodesPerArgument.
+func TestXMLArgumentsLimitSharedBudget(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const scale = bodyprocessors.MaxNodesPerArgument
+	for _, tc := range []struct {
+		name  string
+		body  string
+		limit int
+	}{
+		{
+			name: "content_only",
+			body: func() string {
+				b := strings.Builder{}
+				b.WriteString("<root>")
+				for i := 0; i < 10*scale; i++ {
+					fmt.Fprintf(&b, `<e>v%d</e>`, i)
+				}
+				b.WriteString("</root>")
+				return b.String()
+			}(),
+			limit: 5,
+		},
+		{
+			// Equal numbers of attributes and text nodes, together more than the
+			// budget: it must run out across both kinds of member, not per kind.
+			name: "attributes_and_content",
+			body: func() string {
+				b := strings.Builder{}
+				b.WriteString("<root>")
+				for i := 0; i < 5*scale; i++ {
+					fmt.Fprintf(&b, `<e a="a%d">t%d</e>`, i, i)
+				}
+				b.WriteString("</root>")
+				return b.String()
+			}(),
+			limit: 8,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			err := bp.ProcessRequest(strings.NewReader(tc.body), v, plugintypes.BodyProcessorOptions{
+				ArgumentLimit: tc.limit,
+			})
+			if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+				t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+			}
+			if want, have := tc.limit*scale, len(v.RequestXML().FindAll()); want != have {
+				t.Errorf("REQUEST_XML must hold exactly the budget, want %d members, have %d", want, have)
+			}
+		})
+	}
+}
+
+// TestXMLOrdinaryDocumentsAccepted asserts that documents an ordinary client
+// sends parse whole at the shipped default limit: a SOAP response of several
+// hundred records and a configuration document of several hundred elements
+// both hold more nodes than there are arguments in the budget.
+func TestXMLOrdinaryDocumentsAccepted(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	soap := strings.Builder{}
+	soap.WriteString(`<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetOrdersResponse xmlns="urn:orders"><Orders>`)
+	for i := 0; i < 500; i++ {
+		fmt.Fprintf(&soap, `<Order id="%d" currency="EUR"><Number>ORD-%d</Number><Customer>Customer %d</Customer><Total>%d.99</Total></Order>`, i, i, i, i)
+	}
+	soap.WriteString(`</Orders></GetOrdersResponse></soap:Body></soap:Envelope>`)
+
+	config := strings.Builder{}
+	config.WriteString("<configuration>")
+	for i := 0; i < 600; i++ {
+		fmt.Fprintf(&config, `<setting name="option.%d">value %d</setting>`, i, i)
+	}
+	config.WriteString("</configuration>")
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "soap_records", body: soap.String()},
+		{name: "config_elements", body: config.String()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			if err := bp.ProcessRequest(strings.NewReader(tc.body), v, plugintypes.BodyProcessorOptions{
+				ArgumentLimit: 1000,
+			}); err != nil {
+				t.Fatalf("rejected a %d byte document holding %d members: %v", len(tc.body), len(v.RequestXML().FindAll()), err)
+			}
+		})
+	}
+}
+
+// TestXMLNodeFloodTrips asserts that a node count no document carries still
+// exhausts the budget, so REQUEST_XML cannot be grown without bound.
+func TestXMLNodeFloodTrips(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const limit = 1000
+	body := strings.Builder{}
+	body.WriteString("<root>")
+	for i := 0; i < limit*bodyprocessors.MaxNodesPerArgument*2; i++ {
+		fmt.Fprintf(&body, `<e a="v%d">t%d</e>`, i, i)
+	}
+	body.WriteString("</root>")
+
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		ArgumentLimit: limit,
+	})
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if want, have := limit*bodyprocessors.MaxNodesPerArgument, len(v.RequestXML().FindAll()); want != have {
+		t.Errorf("REQUEST_XML must hold exactly the budget, want %d members, have %d", want, have)
+	}
+}
+
+// deepJSONBody nests levels objects, each keyed by a 1000-character name, and
+// places leaves leaf-valued members at the bottom. Every leaf is stored under
+// the full accumulated path, so stored bytes grow with levels*leaves while the
+// body grows only with levels+leaves.
+func deepJSONBody(levels, leaves int) string {
+	pad := strings.Repeat("A", 1000)
+	body := strings.Builder{}
+	for i := 0; i < levels; i++ {
+		fmt.Fprintf(&body, `{"z":1,"%s":`, pad)
+	}
+	if leaves == 0 {
+		body.WriteString("1")
+	} else {
+		body.WriteString("{")
+		for i := 0; i < leaves; i++ {
+			if i > 0 {
+				body.WriteString(",")
+			}
+			fmt.Fprintf(&body, `"L%d":1`, i)
+		}
+		body.WriteString("}")
+	}
+	body.WriteString(strings.Repeat("}", levels))
+	return body.String()
+}
+
+// TestJSONAmplifyingNestingStopped asserts that bodies which inflate stored
+// bytes far beyond their own size are stopped by the decoded-bytes budget,
+// well before the member count alone would bound the memory they hold.
+func TestJSONAmplifyingNestingStopped(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name           string
+		levels, leaves int
+	}{
+		// One long path per level: the depth alone drives the inflation.
+		{name: "deep_chain", levels: 900, leaves: 0},
+		// Many leaves sharing one long prefix. Each individual path stays
+		// modest, so a per-key length cap does not catch this shape; only the
+		// cumulative byte budget does.
+		{name: "wide_under_long_prefix", levels: 60, leaves: 1000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := deepJSONBody(tc.levels, tc.leaves)
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			err := bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+				RequestBodyRecursionLimit: 1024,
+				ArgumentLimit:             1000,
+			})
+			if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+				t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+			}
+			// The stored bytes must stay within the budget the body earns
+			// rather than growing with depth*leaves.
+			stored := 0
+			for _, m := range v.ArgsPost().FindAll() {
+				stored += len(m.Key()) + len(m.Value())
+			}
+			if maxStored := len(body) + (1 << 20); stored > maxStored {
+				t.Errorf("stored %d bytes from a %d byte body, budget is %d", stored, len(body), maxStored)
+			}
+		})
+	}
+}
+
+// TestJSONLargeBodiesAccepted asserts the decoded-bytes budget does not reject
+// legitimate bodies: it scales with the input, so large flat bodies and
+// realistically nested ones parse without error.
+func TestJSONLargeBodiesAccepted(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Large flat bodies at two sizes, each staying under ArgumentLimit members.
+	for _, members := range []int{200, 900} {
+		t.Run(fmt.Sprintf("flat_%d_members", members), func(t *testing.T) {
+			value := strings.Repeat("x", 6000)
+			body := strings.Builder{}
+			body.WriteString("{")
+			for i := 0; i < members; i++ {
+				if i > 0 {
+					body.WriteString(",")
+				}
+				fmt.Fprintf(&body, `"field_name_%d":"%s"`, i, value)
+			}
+			body.WriteString("}")
+
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			if err := bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+				RequestBodyRecursionLimit: 1024,
+				ArgumentLimit:             1000,
+			}); err != nil {
+				t.Fatalf("rejected a %d byte flat body: %v", body.Len(), err)
+			}
+			if want, have := members, len(v.ArgsPost().FindAll()); want != have {
+				t.Errorf("unexpected number of members, want %d, have %d", want, have)
+			}
+		})
+	}
+
+	// A nested body with descriptive key names: an array of records each
+	// holding a nested object. Its flattened paths are far longer than a flat
+	// body's, which is what the slack in the budget covers.
+	t.Run("nested_records", func(t *testing.T) {
+		payload := strings.Repeat("y", 10000)
+		body := strings.Builder{}
+		body.WriteString(`{"records":[`)
+		for i := 0; i < 300; i++ {
+			if i > 0 {
+				body.WriteString(",")
+			}
+			fmt.Fprintf(&body, `{"id":%d,"payload":"%s","metadata":{"tag":"tag%d"}}`, i, payload, i)
+		}
+		body.WriteString("]}")
+
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		if err := bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+			RequestBodyRecursionLimit: 1024,
+			ArgumentLimit:             1000,
+		}); err != nil {
+			t.Fatalf("rejected a %d byte nested body: %v", body.Len(), err)
+		}
+		// 300 records x (id, payload, metadata.tag), plus the length of the
+		// records array.
+		if want, have := 901, len(v.ArgsPost().FindAll()); want != have {
+			t.Errorf("unexpected number of members, want %d, have %d", want, have)
+		}
+	})
+
+	// Deeply nested with long-ish key names, still under the member cap.
+	t.Run("deep_config", func(t *testing.T) {
+		var build func(depth, fanout int) string
+		build = func(depth, fanout int) string {
+			if depth == 0 {
+				return `"value"`
+			}
+			s := strings.Builder{}
+			s.WriteString("{")
+			for i := 0; i < fanout; i++ {
+				if i > 0 {
+					s.WriteString(",")
+				}
+				fmt.Fprintf(&s, `"configuration_section_%d":%s`, i, build(depth-1, fanout))
+			}
+			s.WriteString("}")
+			return s.String()
+		}
+		body := build(9, 2)
+
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		if err := bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+			RequestBodyRecursionLimit: 1024,
+			ArgumentLimit:             1000,
+		}); err != nil {
+			t.Fatalf("rejected a %d byte deeply nested body: %v", len(body), err)
+		}
+		// A binary tree of depth 9 carries one leaf per path, and the body holds
+		// no arrays, so no length entry is recorded.
+		if want, have := 512, len(v.ArgsPost().FindAll()); want != have {
+			t.Errorf("unexpected number of members, want %d, have %d", want, have)
+		}
+	})
+}
+
+func TestJSONResponseArgumentsLimit(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Builder{}
+	body.WriteString("{")
+	for i := 0; i < 10; i++ {
+		if i > 0 {
+			body.WriteString(",")
+		}
+		fmt.Fprintf(&body, `"k%d":"v"`, i)
+	}
+	body.WriteString("}")
+
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessResponse(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		ArgumentLimit: 5,
+	})
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if want, have := 5, len(v.ResponseArgs().FindAll()); want != have {
+		t.Errorf("the collection must fill to the limit, want %d members, have %d", want, have)
+	}
+
+	v = corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	if err := bp.ProcessResponse(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want, have := 10, len(v.ResponseArgs().FindAll()); want != have {
+		t.Errorf("unexpected number of members, want %d, have %d", want, have)
+	}
+}
+
+// TestMultipartFilePartsArgumentsLimit asserts that a file part costs one
+// member of the argument budget, so a form may carry exactly ArgumentLimit file
+// parts and a bulk upload of several hundred passes at the shipped default.
+// FILES, FILES_NAMES, FILES_SIZES and FILES_TMP_NAMES are four views of the
+// same part and are charged once between them, which also keeps the outcome
+// independent of environment.HasAccessToFS. Part headers use their own budget,
+// so every part the parse reaches records its Content-Disposition.
+func TestMultipartFilePartsArgumentsLimit(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("multipart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name    string
+		limit   int
+		files   int
+		wantErr bool
+	}{
+		{name: "bulk_upload_at_default_limit", limit: 1000, files: 400},
+		{name: "at_limit", limit: 12, files: 12},
+		{name: "over_limit", limit: 12, files: 13, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := strings.Builder{}
+			for i := 0; i < tc.files; i++ {
+				fmt.Fprintf(&body, "--X\r\nContent-Disposition: form-data; name=\"f%d\"; filename=\"file%d.txt\"\r\n\r\ndata\r\n", i, i)
+			}
+			body.WriteString("--X--\r\n")
+
+			dir := t.TempDir()
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			err := bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+				Mime:          "multipart/form-data; boundary=X",
+				StoragePath:   dir,
+				ArgumentLimit: tc.limit,
+			})
+			wantFiles := tc.files
+			wantHeaders := tc.files
+			if tc.wantErr {
+				if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+					t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+				}
+				wantFiles = tc.limit
+				// The part that exhausts the budget is stopped after its headers
+				// were recorded.
+				wantHeaders = tc.limit + 1
+			} else if err != nil {
+				t.Fatalf("rejected %d file parts under a limit of %d: %v", tc.files, tc.limit, err)
+			}
+			for _, col := range []struct {
+				name    string
+				members int
+			}{
+				{"FILES", len(v.Files().FindAll())},
+				{"FILES_NAMES", len(v.FilesNames().FindAll())},
+				{"FILES_SIZES", len(v.FilesSizes().FindAll())},
+			} {
+				if want, have := wantFiles, col.members; want != have {
+					t.Errorf("unexpected %s members, want %d, have %d", col.name, want, have)
+				}
+			}
+			if environment.HasAccessToFS {
+				if want, have := wantFiles, len(v.FilesTmpNames().FindAll()); want != have {
+					t.Errorf("unexpected FILES_TMP_NAMES members, want %d, have %d", want, have)
+				}
+				entries, err := os.ReadDir(dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if want, have := wantFiles, len(entries); want != have {
+					t.Errorf("unexpected number of temp files, want %d, have %d", want, have)
+				}
+			}
+			if want, have := wantHeaders, len(v.MultipartPartHeaders().FindAll()); want != have {
+				t.Errorf("unexpected MULTIPART_PART_HEADERS members, want %d, have %d", want, have)
+			}
+		})
+	}
+}
+
+// TestMultipartMixedPartsShareOneBudget asserts that field and file parts draw
+// on the same budget at one member each, so a form of files and fields is
+// admitted up to the total number of parts.
+func TestMultipartMixedPartsShareOneBudget(t *testing.T) {
+	const limit = 20
+	body := strings.Builder{}
+	for i := 0; i < 10; i++ {
+		fmt.Fprintf(&body, "--X\r\nContent-Disposition: form-data; name=\"f%d\"; filename=\"file%d.txt\"\r\n\r\ndata\r\n", i, i)
+		fmt.Fprintf(&body, "--X\r\nContent-Disposition: form-data; name=\"k%d\"\r\n\r\nv\r\n", i)
+	}
+	body.WriteString("--X--\r\n")
+
+	bp, err := bodyprocessors.GetBodyProcessor("multipart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	if err := bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		Mime:          "multipart/form-data; boundary=X",
+		StoragePath:   t.TempDir(),
+		ArgumentLimit: limit,
+	}); err != nil {
+		t.Fatalf("rejected %d parts under a limit of %d: %v", limit, limit, err)
+	}
+	if want, have := 10, len(v.Files().FindAll()); want != have {
+		t.Errorf("unexpected FILES members, want %d, have %d", want, have)
+	}
+	if want, have := 10, len(v.ArgsPost().FindAll()); want != have {
+		t.Errorf("unexpected ARGS_POST members, want %d, have %d", want, have)
+	}
+}
+
+// TestMultipartHeaderFlood asserts that a part-header flood on the first part
+// does not empty the argument collections, and that when the flood does exhaust
+// the header budget the parse reports ErrArgumentsLimit: MULTIPART_PART_HEADERS
+// then holds nothing for the later parts, so a ruleset has to be able to see
+// that the collection is incomplete.
+func TestMultipartHeaderFlood(t *testing.T) {
+	const limit = 1000
+	const headerLimit = limit * bodyprocessors.MaxHeadersPerPart
+
+	for _, tc := range []struct {
+		name             string
+		junk             int
+		wantErr          bool
+		wantLaterHeaders int
+	}{
+		{name: "under_budget", junk: 10, wantErr: false, wantLaterHeaders: 1},
+		{name: "over_budget", junk: headerLimit + 200, wantErr: true, wantLaterHeaders: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := strings.Builder{}
+			body.WriteString("--X\r\nContent-Disposition: form-data; name=\"junk\"\r\n")
+			for i := 0; i < tc.junk; i++ {
+				fmt.Fprintf(&body, "x%d: b\r\n", i)
+			}
+			body.WriteString("\r\npad\r\n")
+			body.WriteString("--X\r\nContent-Disposition: form-data; name=\"q\"\r\n\r\nvalue\r\n")
+			body.WriteString("--X--\r\n")
+
+			bp, err := bodyprocessors.GetBodyProcessor("multipart")
+			if err != nil {
+				t.Fatal(err)
+			}
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			err = bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+				Mime:          "multipart/form-data; boundary=X",
+				StoragePath:   t.TempDir(),
+				ArgumentLimit: limit,
+			})
+			if tc.wantErr {
+				if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+					t.Fatalf("header truncation not reported, want ErrArgumentsLimit, got %v", err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			// The argument collections fill regardless of the header flood.
+			if want, have := 1, len(v.ArgsPost().Get("q")); want != have {
+				t.Errorf("malicious field dropped by header flood: want %d value, have %d", want, have)
+			}
+			if have := len(v.MultipartPartHeaders().FindAll()); have > headerLimit {
+				t.Errorf("MULTIPART_PART_HEADERS exceeds its budget: have %d", have)
+			}
+			if want, have := tc.wantLaterHeaders, len(v.MultipartPartHeaders().Get("q")); want != have {
+				t.Errorf("unexpected headers recorded for the later part, want %d, have %d", want, have)
+			}
+		})
+	}
+}
+
+// TestMultipartHeaderTruncationDeterministic asserts that when the part-header
+// budget runs out mid-part, the headers kept are the same on every run: they
+// are recorded in sorted key order rather than header map order.
+func TestMultipartHeaderTruncationDeterministic(t *testing.T) {
+	const limit = 4
+	const headerLimit = limit * bodyprocessors.MaxHeadersPerPart
+	// One part offering more headers than the budget admits, so the recorded
+	// ones are a prefix of the sorted keys.
+	b := strings.Builder{}
+	b.WriteString("--X\r\nContent-Disposition: form-data; name=\"f\"\r\n")
+	want := []string{`Content-Disposition: form-data; name="f"`}
+	for i := 0; i < headerLimit+8; i++ {
+		fmt.Fprintf(&b, "X-A%02d: %d\r\n", i, i)
+		if len(want) < headerLimit {
+			want = append(want, fmt.Sprintf("X-A%02d: %d", i, i))
+		}
+	}
+	b.WriteString("\r\nv\r\n--X--\r\n")
+	body := b.String()
+
+	bp, err := bodyprocessors.GetBodyProcessor("multipart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		err := bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+			Mime:          "multipart/form-data; boundary=X",
+			StoragePath:   t.TempDir(),
+			ArgumentLimit: limit,
+		})
+		if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+			t.Fatalf("run %d: expected ErrArgumentsLimit, got %v", i, err)
+		}
+		if have := v.MultipartPartHeaders().Get("f"); !reflect.DeepEqual(want, have) {
+			t.Fatalf("run %d: truncation is not a stable prefix, want %q, have %q", i, want, have)
+		}
+	}
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+
+// TestMultipartTempFileAlwaysRegistered asserts that a temp file created for a
+// file part is recorded in FILES_TMP_NAMES even when the part fails to be
+// copied, because transaction cleanup only removes the files listed there.
+func TestMultipartTempFileAlwaysRegistered(t *testing.T) {
+	if !environment.HasAccessToFS {
+		t.Skip("no filesystem access")
+	}
+	head := "--X\r\nContent-Disposition: form-data; name=\"f\"; filename=\"a.txt\"\r\n\r\n"
+	body := io.MultiReader(strings.NewReader(head+strings.Repeat("A", 8192)), errReader{})
+
+	bp, err := bodyprocessors.GetBodyProcessor("multipart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	if err := bp.ProcessRequest(body, v, plugintypes.BodyProcessorOptions{
+		Mime:        "multipart/form-data; boundary=X",
+		StoragePath: dir,
+	}); err == nil {
+		t.Fatal("expected the copy to fail")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected a temp file to have been created")
+	}
+	if want, have := len(entries), len(v.FilesTmpNames().FindAll()); want != have {
+		t.Errorf("%d temp files on disk but %d in FILES_TMP_NAMES: unregistered files are never cleaned up", want, have)
+	}
+}
+
+// TestJSONTruncatedArrayLength asserts that stopping inside an array does not
+// record the array length under a path the document does not have, and that the
+// decoded-bytes budget names itself instead of pointing at SecArgumentsLimit.
+func TestJSONTruncatedArrayLength(t *testing.T) {
+	body := strings.Builder{}
+	body.WriteString(`[{"`)
+	body.WriteString(strings.Repeat("K", 400))
+	body.WriteString(`":{`)
+	for i := 0; i < 20000; i++ {
+		if i > 0 {
+			body.WriteString(",")
+		}
+		fmt.Fprintf(&body, `"%d":1`, i)
+	}
+	body.WriteString("}}]")
+
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 1024,
+	})
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "decoded size") {
+		t.Errorf("the decoded-bytes budget is reported as an argument count limit: %q", err)
+	}
+	// The enclosing array stopped on the error its element raised, so it has no
+	// length entry either.
+	if have := v.ArgsPost().Get("json"); len(have) != 0 {
+		t.Errorf("the enclosing array reports a length after stopping early: json = %q", have)
+	}
+}
+
+// TestJSONTruncatedArrayLengthNotRecorded asserts that an array whose iteration
+// stopped early records no length entry: the elements past the stop were never
+// counted, so any number written there would understate the array and let a
+// rule counting its size be talked down by a body shaped to trip the limit.
+func TestJSONTruncatedArrayLengthNotRecorded(t *testing.T) {
+	body := strings.Builder{}
+	body.WriteString(`{"a":[`)
+	for i := 0; i < 10; i++ {
+		if i > 0 {
+			body.WriteString(",")
+		}
+		fmt.Fprintf(&body, "%d", i)
+	}
+	body.WriteString("]}")
+
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 10,
+		ArgumentLimit:             5,
+	})
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if have := v.ArgsPost().Get("json.a"); len(have) != 0 {
+		t.Errorf("a truncated array reports a length, json.a = %q, the array holds 10 elements", have)
+	}
+}
+
+// TestJSONArgumentCountLimitError asserts that the argument count limit still
+// reports the plain sentinel, so raising SecArgumentsLimit is an actionable
+// answer to that message.
+func TestJSONArgumentCountLimitError(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessRequest(strings.NewReader(`{"a":1,"b":2,"c":3}`), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 10,
+		ArgumentLimit:             2,
+	})
+	// Compared by identity: this path must report the count limit unwrapped.
+	if err != bodyprocessors.ErrArgumentsLimit {
+		t.Fatalf("expected the bare sentinel, got %v", err)
+	}
+}
+
+// TestMultipartHeaderBudgetExactLimit offers one header more than the budget
+// admits: exactly the budget must be recorded and the truncation reported.
+func TestMultipartHeaderBudgetExactLimit(t *testing.T) {
+	const limit = 5
+	const headerLimit = limit * bodyprocessors.MaxHeadersPerPart
+	body := strings.Builder{}
+	body.WriteString("--X\r\nContent-Disposition: form-data; name=\"f\"\r\n")
+	// Content-Disposition already counts as one header; add headerLimit more so
+	// the budget is exceeded and must stop at exactly headerLimit recorded
+	// headers.
+	for i := 0; i < headerLimit; i++ {
+		fmt.Fprintf(&body, "x%d: b\r\n", i)
+	}
+	body.WriteString("\r\nv\r\n")
+	body.WriteString("--X--\r\n")
+
+	bp, err := bodyprocessors.GetBodyProcessor("multipart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		Mime:          "multipart/form-data; boundary=X",
+		StoragePath:   t.TempDir(),
+		ArgumentLimit: limit,
+	})
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if want, have := headerLimit, len(v.MultipartPartHeaders().FindAll()); want != have {
+		t.Errorf("part-header budget not filled to exactly the limit: want %d, have %d", want, have)
+	}
+}
+
+// TestURLEncodedTruncationDeterministic asserts that truncation keeps the
+// first ArgumentLimit values in document order on every run.
+func TestURLEncodedTruncationDeterministic(t *testing.T) {
+	const body = "a=1&a=2&a=3&a=4&b=1&c=1&d=1"
+	bp, err := bodyprocessors.GetBodyProcessor("urlencoded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 20; i++ {
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		err := bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+			ArgumentLimit: 5,
+		})
+		if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+			t.Fatalf("run %d: expected ErrArgumentsLimit, got %v", i, err)
+		}
+		if want, have := 5, len(v.ArgsPost().FindAll()); want != have {
+			t.Fatalf("run %d: unexpected number of members, want %d, have %d", i, want, have)
+		}
+		for key, want := range map[string]int{"a": 4, "b": 1, "c": 0, "d": 0} {
+			if have := len(v.ArgsPost().Get(key)); want != have {
+				t.Fatalf("run %d: unexpected number of values for %q, want %d, have %d", i, key, want, have)
+			}
+		}
+	}
+}
+
+// TestURLEncodedRepeatedKeyFillsToLimit asserts that a single key with more
+// values than the limit still fills ARGS_POST up to the limit.
+func TestURLEncodedRepeatedKeyFillsToLimit(t *testing.T) {
+	pairs := make([]string, 0, 1002)
+	for i := 0; i < 1002; i++ {
+		pairs = append(pairs, fmt.Sprintf("evil=%d", i))
+	}
+	bp, err := bodyprocessors.GetBodyProcessor("urlencoded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessRequest(strings.NewReader(strings.Join(pairs, "&")), v, plugintypes.BodyProcessorOptions{
+		ArgumentLimit: 1000,
+	})
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	values := v.ArgsPost().Get("evil")
+	if want, have := 1000, len(values); want != have {
+		t.Fatalf("unexpected number of values, want %d, have %d", want, have)
+	}
+	if values[0] != "0" || values[999] != "999" {
+		t.Errorf("values are not in document order: first %q, last %q", values[0], values[999])
+	}
+}
+
+// TestJSONRawBodyStoredOnArgumentsLimit asserts that TX:json_request_body and
+// TX:json_response_body keep the raw body when the argument limit trips, so
+// @validateSchema still has data to validate.
+func TestJSONRawBodyStoredOnArgumentsLimit(t *testing.T) {
+	body := strings.Builder{}
+	body.WriteString("{")
+	for i := 0; i < 10; i++ {
+		if i > 0 {
+			body.WriteString(",")
+		}
+		fmt.Fprintf(&body, `"k%d":"v"`, i)
+	}
+	body.WriteString("}")
+
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 10,
+		ArgumentLimit:             5,
+	})
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if have := v.TX().Get("json_request_body"); len(have) != 1 || have[0] != body.String() {
+		t.Errorf("TX:json_request_body does not hold the raw body: %q", have)
+	}
+
+	v = corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessResponse(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 10,
+		ArgumentLimit:             5,
+	})
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if have := v.TX().Get("json_response_body"); len(have) != 1 || have[0] != body.String() {
+		t.Errorf("TX:json_response_body does not hold the raw body: %q", have)
+	}
+}
+
+// TestJSONResponseDepthLimit asserts that the response path applies the
+// configured recursion limit.
+func TestJSONResponseDepthLimit(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Repeat("[", 200) + strings.Repeat("]", 200)
+
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessResponse(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 100,
+	})
+	if err == nil || errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected recursion error, got %v", err)
+	}
+	// The raw body must still be stored for @validateSchema even though the
+	// depth limit stopped the parse before any argument was flattened.
+	if have := v.TX().Get("json_response_body"); len(have) != 1 || have[0] != body {
+		t.Errorf("TX:json_response_body not stored on the depth-error path: %q", have)
+	}
+
+	v = corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	if err := bp.ProcessResponse(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 500,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type countingReader struct {
+	r io.Reader
+	n int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += n
+	return n, err
+}
+
+// TestArgumentsLimitStopsReading asserts that once the limit trips, the XML
+// and multipart processors stop consuming the body instead of parsing it to
+// the end and trimming afterwards.
+func TestArgumentsLimitStopsReading(t *testing.T) {
+	xmlBody := strings.Builder{}
+	xmlBody.WriteString("<root>")
+	for i := 0; i < 100000; i++ {
+		fmt.Fprintf(&xmlBody, `<e a="v%d"/>`, i)
+	}
+	xmlBody.WriteString("</root>")
+
+	multipartBody := strings.Builder{}
+	for i := 0; i < 50000; i++ {
+		fmt.Fprintf(&multipartBody, "--X\r\nContent-Disposition: form-data; name=\"k%d\"\r\n\r\nv\r\n", i)
+	}
+	multipartBody.WriteString("--X--\r\n")
+
+	for _, tc := range []struct {
+		name string
+		mime string
+		body string
+	}{
+		{name: "xml", body: xmlBody.String()},
+		{name: "multipart", mime: "multipart/form-data; boundary=X", body: multipartBody.String()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bp, err := bodyprocessors.GetBodyProcessor(tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cr := &countingReader{r: strings.NewReader(tc.body)}
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			err = bp.ProcessRequest(cr, v, plugintypes.BodyProcessorOptions{
+				Mime:          tc.mime,
+				StoragePath:   t.TempDir(),
+				ArgumentLimit: 10,
+			})
+			if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+				t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+			}
+			if cr.n >= 64<<10 {
+				t.Errorf("processor read %d bytes of a %d byte body after the limit tripped", cr.n, len(tc.body))
+			}
+		})
+	}
+}
+
+// TestURLEncodedArgumentsLimitAllocs asserts that arguments past the limit are
+// never decoded into an intermediate map: the allocation volume must stay
+// close to the raw body copy rather than growing with the argument count.
+func TestURLEncodedArgumentsLimitAllocs(t *testing.T) {
+	pairs := make([]string, 0, 100000)
+	for i := 0; i < 100000; i++ {
+		pairs = append(pairs, fmt.Sprintf("key%06d=value", i))
+	}
+	body := strings.Join(pairs, "&")
+
+	bp, err := bodyprocessors.GetBodyProcessor("urlencoded")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	err = bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+		ArgumentLimit: 10,
+	})
+	runtime.ReadMemStats(&after)
+
+	if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if want, have := 10, len(v.ArgsPost().FindAll()); want != have {
+		t.Fatalf("unexpected number of members, want %d, have %d", want, have)
+	}
+	// The raw body is copied once for REQUEST_BODY (~len(body) bytes); parsing
+	// all 100k arguments into a map would add several times that.
+	allocated := after.TotalAlloc - before.TotalAlloc
+	if maxAllocated := uint64(len(body)) + 1<<20; allocated > maxAllocated {
+		t.Errorf("allocated %d bytes, expected at most %d", allocated, maxAllocated)
+	}
+}
+
+// TestJSONArrayLengthNotCountedAsArgument asserts that the array-length entry a
+// non-empty array records is not charged against SecArgumentsLimit: ModSecurity
+// counts scalar values only, so a body of exactly ArgumentLimit scalars is
+// accepted whole and the entry past it is what trips the limit.
+func TestJSONArrayLengthNotCountedAsArgument(t *testing.T) {
+	const limit = 1000
+	body := func(scalars int) string {
+		b := strings.Builder{}
+		b.WriteString(`{"a":[`)
+		for i := 0; i < scalars; i++ {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, "%d", i)
+		}
+		b.WriteString("]}")
+		return b.String()
+	}
+
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		scalars int
+		wantErr bool
+	}{
+		{scalars: limit - 1, wantErr: false},
+		{scalars: limit, wantErr: false},
+		{scalars: limit + 1, wantErr: true},
+	} {
+		t.Run(fmt.Sprintf("%d_scalars", tc.scalars), func(t *testing.T) {
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			err := bp.ProcessRequest(strings.NewReader(body(tc.scalars)), v, plugintypes.BodyProcessorOptions{
+				RequestBodyRecursionLimit: 10,
+				ArgumentLimit:             limit,
+			})
+			if tc.wantErr {
+				if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+					t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %d scalars under a limit of %d: %v", tc.scalars, limit, err)
+			}
+			// The scalars plus the array-length entry, which is still recorded.
+			if want, have := tc.scalars+1, len(v.ArgsPost().FindAll()); want != have {
+				t.Errorf("unexpected number of members, want %d, have %d", want, have)
+			}
+			if want, have := []string{strconv.Itoa(tc.scalars)}, v.ArgsPost().Get("json.a"); !reflect.DeepEqual(want, have) {
+				t.Errorf("unexpected array length entry, want %q, have %q", want, have)
+			}
+		})
+	}
+}
+
+// TestJSONArrayLengthEntriesBounded asserts that ARGS_POST stays within the
+// argument limit scaled by MaxEntriesPerArgument+1 whatever shape the body
+// takes, and that reaching the array-length budget never denies a body. An
+// array records its length without spending argument budget, so a body of
+// nested arrays stores a member per level while the argument count barely
+// moves; only a bound on those entries catches that. The entries are metadata
+// ModSecurity never records, so exhausting their budget drops them and the
+// parse continues: a document can hold more arrays than arguments, and failing
+// there would deny bodies carrying no arguments at all.
+func TestJSONArrayLengthEntriesBounded(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const limit = 1000
+	maxMembers := limit * (bodyprocessors.MaxEntriesPerArgument + 1)
+
+	chains := func(n, depth int) string {
+		parts := make([]string, n)
+		for i := range parts {
+			parts[i] = strings.Repeat("[", depth) + "1" + strings.Repeat("]", depth)
+		}
+		return "[" + strings.Join(parts, ",") + "]"
+	}
+	// Rows of empty cells: every array is non-empty but the body carries no
+	// value at all, so ModSecurity counts zero arguments for it.
+	sparseRows := func(rows int) string {
+		parts := make([]string, rows)
+		for i := range parts {
+			parts[i] = "[[],[],[],[]]"
+		}
+		return `{"rows":[` + strings.Join(parts, ",") + `]}`
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		// arguments is what ModSecurity would count for the body, which decides
+		// whether the truncation may be reported.
+		arguments int
+	}{
+		{name: "nested_chains", body: chains(1000, 28), arguments: 1000},
+		{name: "nested_chains_whitespace_padded", body: chains(1000, 28) + strings.Repeat(" ", 8<<20), arguments: 1000},
+		{name: "empty_containers", body: "[" + strings.TrimSuffix(strings.Repeat("[[[]]],", 20000), ",") + "]", arguments: 0},
+		{name: "sparse_rows", body: sparseRows(2000), arguments: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			err := bp.ProcessRequest(strings.NewReader(tc.body), v, plugintypes.BodyProcessorOptions{
+				RequestBodyRecursionLimit: 1024,
+				ArgumentLimit:             limit,
+			})
+			have := len(v.ArgsPost().FindAll())
+			if have > maxMembers {
+				t.Errorf("a %d byte body stored %d members, the bound is %d", len(tc.body), have, maxMembers)
+			}
+			// Stated absolutely as well, so loosening MaxEntriesPerArgument
+			// cannot move both sides of the comparison above together.
+			if have > 3000 {
+				t.Errorf("a %d byte body stored %d members under a limit of %d", len(tc.body), have, limit)
+			}
+			// A body under the argument limit must not be reported as truncated,
+			// however many arrays it holds.
+			if tc.arguments < limit && err != nil {
+				t.Errorf("a body carrying %d arguments was reported as truncated: %v", tc.arguments, err)
+			}
+		})
+	}
+
+	t.Run("duplicate_keys_report_the_surviving_array", func(t *testing.T) {
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		if err := bp.ProcessRequest(strings.NewReader(`{"a":[1,2,3],"a":[4,5]}`), v, plugintypes.BodyProcessorOptions{
+			RequestBodyRecursionLimit: 1024,
+			ArgumentLimit:             limit,
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Later keys overwrite earlier ones, so the array a rule sees is [4,5].
+		if want, have := "2", strings.Join(v.ArgsPost().Get("json.a"), ","); want != have {
+			t.Errorf("unexpected array length entry, want %q, have %q", want, have)
+		}
+	})
+
+	t.Run("array_of_empty_containers_keeps_its_length", func(t *testing.T) {
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		if err := bp.ProcessRequest(strings.NewReader(`{"a":[[],[],[]]}`), v, plugintypes.BodyProcessorOptions{
+			RequestBodyRecursionLimit: 1024,
+			ArgumentLimit:             limit,
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want, have := "3", strings.Join(v.ArgsPost().Get("json.a"), ","); want != have {
+			t.Errorf("unexpected array length entry, want %q, have %q", want, have)
+		}
+	})
+
+	// The array budget must not depend on how many scalars the body also holds,
+	// or on the order its keys arrive in: the same document serialised two ways
+	// would otherwise get two verdicts.
+	t.Run("verdict_independent_of_key_order", func(t *testing.T) {
+		arrays := make([]string, 1500)
+		for i := range arrays {
+			arrays[i] = fmt.Sprintf(`"a%d":[[]]`, i)
+		}
+		scalars := make([]string, 700)
+		for i := range scalars {
+			scalars[i] = fmt.Sprintf(`"s%d":1`, i)
+		}
+		arraysFirst := "{" + strings.Join(append(append([]string{}, arrays...), scalars...), ",") + "}"
+		scalarsFirst := "{" + strings.Join(append(append([]string{}, scalars...), arrays...), ",") + "}"
+		var first int
+		for i, body := range []string{arraysFirst, scalarsFirst} {
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			if err := bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+				RequestBodyRecursionLimit: 1024,
+				ArgumentLimit:             limit,
+			}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			have := len(v.ArgsPost().FindAll())
+			if i == 0 {
+				first = have
+				continue
+			}
+			if first != have {
+				t.Errorf("key order changed the result, arrays first stored %d members, scalars first stored %d", first, have)
+			}
+		}
+	})
+}
+
+// TestMultipartTypedPartsWithinArgumentLimit asserts that a form of
+// ArgumentLimit ordinary parts is accepted whole. Two headers per part is the
+// worst case an ordinary client produces, a Content-Disposition plus the
+// Content-Type clients attach to typed parts, and the part-header budget must
+// stay clear of a form built that way.
+func TestMultipartTypedPartsWithinArgumentLimit(t *testing.T) {
+	const limit = 1000
+	body := strings.Builder{}
+	for i := 0; i < limit; i++ {
+		fmt.Fprintf(&body, "--X\r\nContent-Disposition: form-data; name=\"k%d\"\r\nContent-Type: text/plain\r\n\r\nv\r\n", i)
+	}
+	body.WriteString("--X--\r\n")
+
+	bp, err := bodyprocessors.GetBodyProcessor("multipart")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	if err := bp.ProcessRequest(strings.NewReader(body.String()), v, plugintypes.BodyProcessorOptions{
+		Mime:          "multipart/form-data; boundary=X",
+		StoragePath:   t.TempDir(),
+		ArgumentLimit: limit,
+	}); err != nil {
+		t.Fatalf("rejected %d typed parts under a limit of %d: %v", limit, limit, err)
+	}
+	if want, have := limit, len(v.ArgsPost().FindAll()); want != have {
+		t.Errorf("unexpected ARGS_POST members, want %d, have %d", want, have)
+	}
+	if want, have := 2*limit, len(v.MultipartPartHeaders().FindAll()); want != have {
+		t.Errorf("unexpected MULTIPART_PART_HEADERS members, want %d, have %d", want, have)
+	}
+}
+
+// TestJSONRawBodyStoredOnParseFailure asserts that the raw request body reaches
+// TX:json_request_body even when parsing fails outright. Operators like
+// @validateSchema read that variable, and a body the flattener rejects is
+// exactly the one a schema check most needs to see.
+func TestJSONRawBodyStoredOnParseFailure(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		opts plugintypes.BodyProcessorOptions
+	}{
+		{name: "invalid json", body: "{invalid"},
+		{
+			name: "over the recursion limit",
+			body: strings.Repeat("[", 200) + strings.Repeat("]", 200),
+			opts: plugintypes.BodyProcessorOptions{RequestBodyRecursionLimit: 100},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			if err := bp.ProcessRequest(strings.NewReader(tc.body), v, tc.opts); err == nil {
+				t.Fatal("expected the parse to fail")
+			}
+			have := v.TX().Get("json_request_body")
+			if len(have) != 1 || have[0] != tc.body {
+				t.Errorf("the raw body must survive a failed parse, want %q, have %q", tc.body, have)
+			}
+		})
+	}
+}
+
+// TestScaledBudgetsDoNotOverflow asserts that a large SecArgumentsLimit leaves
+// benign bodies accepted. The multipart and XML budgets, and the bound on JSON
+// members, scale the limit by a constant factor; on a 32-bit target that
+// product wraps negative unless it saturates, and a negative budget reads as
+// "nothing fits" or as "unlimited" depending on the comparison, so the same
+// request would be answered differently by a 32-bit and a 64-bit build.
+func TestScaledBudgetsDoNotOverflow(t *testing.T) {
+	for _, tc := range []struct {
+		processor string
+		mime      string
+		body      string
+		collect   func(plugintypes.TransactionVariables) int
+	}{
+		{
+			processor: "multipart",
+			mime:      "multipart/form-data; boundary=X",
+			body:      "--X\r\nContent-Disposition: form-data; name=\"k\"\r\nContent-Type: text/plain\r\n\r\nv\r\n--X--\r\n",
+			collect:   func(v plugintypes.TransactionVariables) int { return len(v.ArgsPost().FindAll()) },
+		},
+		{
+			processor: "xml",
+			body:      `<r a="1"><f>v</f></r>`,
+			collect:   func(v plugintypes.TransactionVariables) int { return len(v.RequestXML().FindAll()) },
+		},
+		{
+			processor: "json",
+			body:      `{"a":[1,2,3],"b":"v"}`,
+			collect:   func(v plugintypes.TransactionVariables) int { return len(v.ArgsPost().FindAll()) },
+		},
+	} {
+		t.Run(tc.processor, func(t *testing.T) {
+			bp, err := bodyprocessors.GetBodyProcessor(tc.processor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			if err := bp.ProcessRequest(strings.NewReader(tc.body), v, plugintypes.BodyProcessorOptions{
+				Mime:                      tc.mime,
+				RequestBodyRecursionLimit: 1024,
+				ArgumentLimit:             math.MaxInt,
+			}); err != nil {
+				t.Fatalf("a benign body was rejected under a large argument limit: %v", err)
+			}
+			if have := tc.collect(v); have == 0 {
+				t.Error("a benign body stored no members under a large argument limit")
+			}
+		})
+	}
+}
+
+// TestJSONSiblingArrayLengthsNotCountedAsArguments asserts the array-length
+// exemption across several arrays rather than one. A body whose scalars are
+// spread over many sibling arrays carries one length entry per array, and if
+// any of them were charged as an argument the body would be denied while
+// holding exactly ArgumentLimit values.
+func TestJSONSiblingArrayLengthsNotCountedAsArguments(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const (
+		arrays          = 50
+		scalarsPerArray = 2
+		limit           = arrays * scalarsPerArray
+	)
+	b := strings.Builder{}
+	b.WriteString("{")
+	for i := 0; i < arrays; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `"k%d":[1,2]`, i)
+	}
+	b.WriteString("}")
+
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	if err := bp.ProcessRequest(strings.NewReader(b.String()), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 1024,
+		ArgumentLimit:             limit,
+	}); err != nil {
+		t.Fatalf("a body of exactly %d values was rejected: %v", limit, err)
+	}
+	// The scalars plus one length entry per array.
+	if want, have := limit+arrays, len(v.ArgsPost().FindAll()); want != have {
+		t.Errorf("unexpected number of members, want %d, have %d", want, have)
+	}
+}
+
+// TestJSONArrayLengthChargedAgainstDecodedBytes asserts that the array-length
+// entry is charged against the decoded-bytes budget. Each entry is stored under
+// its parent's full flattened path, so a document that nests deeply and then
+// fans out into sibling arrays inflates stored bytes through the length entries
+// alone, without storing a single extra scalar.
+func TestJSONArrayLengthChargedAgainstDecodedBytes(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A long prefix every length entry inherits, then many sibling arrays under
+	// it, each holding one scalar.
+	const (
+		prefixDepth = 40
+		siblings    = 3000
+	)
+	b := strings.Builder{}
+	for i := 0; i < prefixDepth; i++ {
+		fmt.Fprintf(&b, `{"prefixsegment%d":`, i)
+	}
+	b.WriteString("{")
+	for i := 0; i < siblings; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `"s%d":[1]`, i)
+	}
+	b.WriteString("}")
+	b.WriteString(strings.Repeat("}", prefixDepth))
+	body := b.String()
+
+	v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+	err = bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+		RequestBodyRecursionLimit: 1024,
+		ArgumentLimit:             siblings * 4,
+	})
+	if err != nil && !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stored := 0
+	for _, m := range v.ArgsPost().FindAll() {
+		stored += len(m.Key()) + len(m.Value())
+	}
+	if maxStored := len(body) + (1 << 20); stored > maxStored {
+		t.Errorf("stored %d bytes from a %d byte body, the budget is %d", stored, len(body), maxStored)
+	}
+}
+
+// TestScaledBudgetsHaveLiteralAnchors pins the two scaling constants against
+// concrete documents and literal member counts. Assertions written in terms of
+// MaxNodesPerArgument or MaxHeadersPerPart move with the constant and so cannot
+// detect a change to it; these cases fail if either is narrowed enough to
+// reject ordinary traffic or widened enough to stop bounding a flood.
+func TestScaledBudgetsHaveLiteralAnchors(t *testing.T) {
+	const limit = 1000
+
+	t.Run("xml_ordinary_document_accepted", func(t *testing.T) {
+		bp, _ := bodyprocessors.GetBodyProcessor("xml")
+		b := strings.Builder{}
+		b.WriteString(`<soap:Envelope xmlns:soap="urn:e"><soap:Body><Orders>`)
+		for i := 0; i < 1200; i++ {
+			fmt.Fprintf(&b, `<Order id="%d" currency="EUR"><Number>ORD-%d</Number><Customer>C%d</Customer><Total>%d.99</Total></Order>`, i, i, i, i)
+		}
+		b.WriteString(`</Orders></soap:Body></soap:Envelope>`)
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		if err := bp.ProcessRequest(strings.NewReader(b.String()), v, plugintypes.BodyProcessorOptions{ArgumentLimit: limit}); err != nil {
+			t.Fatalf("an ordinary SOAP document of 1200 records was rejected: %v", err)
+		}
+		// 1200 records x (2 attributes + 3 text nodes), plus the envelope's
+		// namespace attribute.
+		if want, have := 6001, len(v.RequestXML().FindAll()); want != have {
+			t.Errorf("unexpected REQUEST_XML members, want %d, have %d", want, have)
+		}
+	})
+
+	t.Run("xml_node_flood_trips", func(t *testing.T) {
+		bp, _ := bodyprocessors.GetBodyProcessor("xml")
+		b := strings.Builder{}
+		b.WriteString("<root>")
+		for i := 0; i < 20000; i++ {
+			fmt.Fprintf(&b, `<e a="v%d"/>`, i)
+		}
+		b.WriteString("</root>")
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		err := bp.ProcessRequest(strings.NewReader(b.String()), v, plugintypes.BodyProcessorOptions{ArgumentLimit: limit})
+		if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+			t.Fatalf("a flood of 20000 nodes did not trip the budget: %v", err)
+		}
+	})
+
+	t.Run("multipart_ordinary_form_accepted", func(t *testing.T) {
+		bp, _ := bodyprocessors.GetBodyProcessor("multipart")
+		b := strings.Builder{}
+		for i := 0; i < 900; i++ {
+			fmt.Fprintf(&b, "--X\r\nContent-Disposition: form-data; name=\"k%d\"\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: binary\r\nX-A: 1\r\nX-B: 2\r\nX-C: 3\r\n\r\nv\r\n", i)
+		}
+		b.WriteString("--X--\r\n")
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		if err := bp.ProcessRequest(strings.NewReader(b.String()), v, plugintypes.BodyProcessorOptions{
+			Mime: "multipart/form-data; boundary=X", ArgumentLimit: limit, StoragePath: t.TempDir(),
+		}); err != nil {
+			t.Fatalf("an ordinary form of 900 parts carrying 6 headers each was rejected: %v", err)
+		}
+		// 900 parts x 6 headers.
+		if want, have := 5400, len(v.MultipartPartHeaders().FindAll()); want != have {
+			t.Errorf("unexpected MULTIPART_PART_HEADERS members, want %d, have %d", want, have)
+		}
+	})
+
+	t.Run("multipart_header_flood_trips", func(t *testing.T) {
+		bp, _ := bodyprocessors.GetBodyProcessor("multipart")
+		b := strings.Builder{}
+		for i := 0; i < 900; i++ {
+			b.WriteString("--X\r\n")
+			fmt.Fprintf(&b, "Content-Disposition: form-data; name=\"k%d\"\r\n", i)
+			for h := 0; h < 11; h++ {
+				fmt.Fprintf(&b, "X-P%02d: v\r\n", h)
+			}
+			b.WriteString("\r\nv\r\n")
+		}
+		b.WriteString("--X--\r\n")
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		err := bp.ProcessRequest(strings.NewReader(b.String()), v, plugintypes.BodyProcessorOptions{
+			Mime: "multipart/form-data; boundary=X", ArgumentLimit: limit, StoragePath: t.TempDir(),
+		})
+		if !errors.Is(err, bodyprocessors.ErrArgumentsLimit) {
+			t.Fatalf("a flood of 10800 part headers did not trip the budget: %v", err)
+		}
+	})
+}
+
+// TestJSONDecodedBytesBudgetScalesWithSmallBodies asserts that a small body
+// cannot buy the whole slack. Every member is stored under its full flattened
+// path, so a body that nests deeply and then fans out spends its budget on one
+// long shared prefix: cheap in memory, but each member is fed through every
+// ARGS rule's transformation pipeline, so a fixed slack lets a request of a few
+// kilobytes cost more phase 2 CPU than a legitimate one of a megabyte.
+func TestJSONDecodedBytesBudgetScalesWithSmallBodies(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	deep := func(levels, leaves, keylen, vallen int) string {
+		b := strings.Builder{}
+		k := strings.Repeat("k", keylen)
+		for i := 0; i < levels; i++ {
+			fmt.Fprintf(&b, `{"%s%d":`, k, i)
+		}
+		b.WriteString("{")
+		for i := 0; i < leaves; i++ {
+			if i > 0 {
+				b.WriteString(",")
+			}
+			fmt.Fprintf(&b, `"l%d":"%s"`, i, strings.Repeat("v", vallen))
+		}
+		b.WriteString("}" + strings.Repeat("}", levels))
+		return b.String()
+	}
+	measure := func(t *testing.T, body string) (stored int, tripped bool) {
+		t.Helper()
+		v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+		err := bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+			RequestBodyRecursionLimit: 1024,
+			ArgumentLimit:             1000,
+		})
+		for _, m := range v.ArgsPost().FindAll() {
+			stored += len(m.Key()) + len(m.Value())
+		}
+		return stored, errors.Is(err, bodyprocessors.ErrJSONDecodedSize)
+	}
+
+	t.Run("small_body_with_a_long_shared_prefix_is_stopped", func(t *testing.T) {
+		// A 2 KB body whose every member sits under a 1 KB path.
+		body := strings.Repeat("[", 1000) +
+			`{"s0":"x","s1":"x","s2":"x","s3":"x","s4":"x","s5":"x","s6":"x","s7":"x","s8":"x","s9":"x"}` +
+			strings.Repeat("]", 1000)
+		stored, _ := measure(t, body)
+		// The budget is the body length plus the scaled slack. A fixed slack
+		// let this body store roughly 1 MiB.
+		if maxStored := len(body) * 65; stored > maxStored {
+			t.Errorf("stored %d bytes from a %d byte body, the budget allows %d", stored, len(body), maxStored)
+		}
+	})
+
+	// Legitimately nested bodies stay well inside the scaled budget. The
+	// deepest of these measures about 20x its own size, so the scale has room.
+	for _, tc := range []struct {
+		name                           string
+		levels, leaves, keylen, vallen int
+	}{
+		{"depth20_50leaves", 20, 50, 8, 20},
+		{"depth50_100leaves", 50, 100, 8, 30},
+		{"depth100_100leaves", 100, 100, 10, 40},
+		{"depth10_config", 10, 300, 20, 60},
+		{"api_response", 6, 800, 14, 120},
+	} {
+		t.Run("accepted_"+tc.name, func(t *testing.T) {
+			body := deep(tc.levels, tc.leaves, tc.keylen, tc.vallen)
+			if _, tripped := measure(t, body); tripped {
+				t.Errorf("a legitimately nested %d byte body was stopped by the decoded-bytes budget", len(body))
+			}
+		})
+	}
+}
+
+// TestJSONArgumentFreeBodiesAreNotDenied asserts that a body carrying no
+// arguments is never reported as truncated, however deeply it nests. Array
+// lengths are metadata, so running out of room for them drops entries rather
+// than failing the parse: a body ModSecurity counts zero arguments for must not
+// be denied by a rule written against REQBODY_ERROR.
+func TestJSONArgumentFreeBodiesAreNotDenied(t *testing.T) {
+	bp, err := bodyprocessors.GetBodyProcessor("json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, depth := range []int{100, 129, 200, 500, 1000} {
+		t.Run(fmt.Sprintf("nested_arrays_%d", depth), func(t *testing.T) {
+			body := strings.Repeat("[", depth) + strings.Repeat("]", depth)
+			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})
+			if err := bp.ProcessRequest(strings.NewReader(body), v, plugintypes.BodyProcessorOptions{
+				RequestBodyRecursionLimit: 1024,
+				ArgumentLimit:             1000,
+			}); err != nil {
+				t.Errorf("a %d byte body carrying no arguments was reported as truncated: %v", len(body), err)
+			}
+			// Dropping the entries that do not fit still bounds what is stored.
+			stored := 0
+			for _, m := range v.ArgsPost().FindAll() {
+				stored += len(m.Key()) + len(m.Value())
+			}
+			if maxStored := len(body) * 65; stored > maxStored {
+				t.Errorf("stored %d bytes from a %d byte body, the budget allows %d", stored, len(body), maxStored)
+			}
+		})
+	}
+}

--- a/internal/bodyprocessors/bodyprocessors.go
+++ b/internal/bodyprocessors/bodyprocessors.go
@@ -4,11 +4,39 @@
 package bodyprocessors
 
 import (
+	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 )
+
+// ErrArgumentsLimit is returned by a body processor that could not store a
+// body in full because one of its limits was reached. Members decoded before
+// that point are kept. Most processors stop parsing there; multipart finishes
+// the parse when only its part-header budget was exhausted. Processors may
+// return an error wrapping this one to name the specific limit, so match it
+// with errors.Is rather than by equality.
+var ErrArgumentsLimit = errors.New("arguments limit exceeded")
+
+// scaleArgumentLimit widens the argument limit into a budget larger than the
+// number of arguments allowed, saturating instead of overflowing. The product
+// wraps negative once limit exceeds MaxInt/factor, which a budget check reads
+// as "nothing fits" where it guards on the unscaled limit and as "unlimited"
+// where it guards on the scaled value, so processors sharing one configuration
+// would disagree. MaxInt/factor is reachable on a 32-bit target for a limit the
+// directive accepts, and on any target for a limit set through the Go API. A
+// non-positive limit means unlimited and is returned unchanged.
+func scaleArgumentLimit(limit, factor int) int {
+	if limit <= 0 {
+		return limit
+	}
+	if limit > math.MaxInt/factor {
+		return math.MaxInt
+	}
+	return limit * factor
+}
 
 type bodyProcessorWrapper = func() plugintypes.BodyProcessor
 

--- a/internal/bodyprocessors/json.go
+++ b/internal/bodyprocessors/json.go
@@ -5,6 +5,7 @@ package bodyprocessors
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -27,56 +28,146 @@ func (js *jsonBodyProcessor) ProcessRequest(reader io.Reader, v plugintypes.Tran
 		return err
 	}
 	ss := s.String()
+
+	// Store the raw JSON in the TX variable for validateSchema before parsing,
+	// so operators like @validateSchema keep their data even when parsing stops
+	// early on the argument limit or the recursion-depth limit.
+	// This is needed because RequestBody is a Single interface without a Set method
+	if txVar := v.TX(); txVar != nil {
+		txVar.Set("json_request_body", []string{ss})
+	}
+
 	// Process with recursion limit
 	col := v.ArgsPost()
-	data, err := readJSON(ss, bpo.RequestBodyRecursionLimit)
-	if err != nil {
+	data, err := readJSON(ss, bpo.RequestBodyRecursionLimit, bpo.ArgumentLimit)
+	if err != nil && !errors.Is(err, ErrArgumentsLimit) {
 		return err
 	}
 	for key, value := range data {
 		col.SetIndex(key, 0, value)
 	}
 
-	// Store the raw JSON in the TX variable for validateSchema
-	// This is needed because RequestBody is a Single interface without a Set method
-	if txVar := v.TX(); txVar != nil {
-		// Store the content type and raw body
-		txVar.Set("json_request_body", []string{ss})
-	}
-
-	return nil
+	return err
 }
 
 const ignoreJSONRecursionLimit = -1
 
-func (js *jsonBodyProcessor) ProcessResponse(reader io.Reader, v plugintypes.TransactionVariables, _ plugintypes.BodyProcessorOptions) error {
+// jsonDecodedBytesSlack is the largest allowance added to the body length to
+// form the budget of decoded bytes (flattened keys plus values) a JSON body
+// may produce. Every leaf is stored under its full path
+// ("json.<k1>.<k2>...<kn>.leaf"), so a body that nests deeply and then fans
+// out makes many leaves share one long prefix: stored bytes grow with
+// depth * leaves while the body grows only with depth + leaves. Neither the
+// argument count nor the body length sees that product, so it is bounded
+// directly. Deriving the budget from the body keeps it self-tuning: a
+// legitimate body decodes to roughly its own size plus one path prefix per
+// member, and the slack covers that overhead outright, while the amplifying
+// shapes overshoot it by one to two orders of magnitude.
+const jsonDecodedBytesSlack = 1 << 20
+
+// jsonDecodedBytesScale caps the slack a small body earns. A fixed slack is a
+// fixed amount of amplification every request may buy however small it is, and
+// a body of a couple of kilobytes can spend it entirely on one long shared path
+// prefix: that costs no memory worth the name but feeds every member through
+// each ARGS rule's transformation pipeline, so a 2 KB request can cost more
+// phase 2 CPU than a legitimate one of a megabyte. Tying the slack to the body
+// for small inputs keeps that cost proportional to what was actually sent.
+const jsonDecodedBytesScale = 64
+
+// MaxEntriesPerArgument bounds the array-length entries a JSON body may store
+// for each argument it is allowed. Scalars are capped by the argument limit
+// directly, but the length entry recorded for a non-empty array is not an
+// argument ModSecurity counts and so spends no argument budget: a chain of
+// nested arrays costs one argument and stores one member per level. The
+// decoded-bytes budget cannot stand in for this bound, because a length entry
+// costs only its key and because inter-token whitespace raises a budget derived
+// from the body length without storing anything, so the entries are counted
+// directly. Counting them rather than the size of the whole collection keeps
+// this budget independent of the argument count, so the arguments a body
+// carries cannot change the verdict on its arrays. Together with the argument
+// limit it holds a body to MaxEntriesPerArgument+1 stored members per argument
+// allowed.
+const MaxEntriesPerArgument = 2
+
+// ErrJSONDecodedSize is raised when storing an entry would push a body past its
+// decoded-bytes budget. It wraps ErrArgumentsLimit; the distinct sentinel
+// identifies which limit tripped, so a caller can tell this budget apart from
+// SecArgumentsLimit and decide whether the condition is fatal.
+var ErrJSONDecodedSize = fmt.Errorf("json decoded size limit exceeded: %w", ErrArgumentsLimit)
+
+// ErrJSONRecursionLimit is raised when a body nests deeper than the configured
+// recursion limit. It does not wrap ErrArgumentsLimit: the parse fails and the
+// entries collected so far are discarded, so it reports as a body error.
+var ErrJSONRecursionLimit = errors.New("max recursion reached while reading json object")
+
+// jsonDecodedBudget returns the decoded bytes a body of n bytes may produce.
+// The slack it earns is proportional to it until it reaches the ceiling. The
+// division tests for the product having overflowed, which a body larger than
+// MaxInt/jsonDecodedBytesScale does on a 32-bit target: a wrapped product can
+// land positive as easily as negative, and a small positive one would starve
+// the budget rather than widen it.
+func jsonDecodedBudget(n int) int {
+	slack := n * jsonDecodedBytesScale
+	if slack > jsonDecodedBytesSlack || slack/jsonDecodedBytesScale != n {
+		slack = jsonDecodedBytesSlack
+	}
+	return n + slack
+}
+
+// lengthBudgetLeft reports whether another array-length entry fits the budget
+// those entries share, which is the argument limit scaled by
+// MaxEntriesPerArgument. A non-positive limit means unlimited.
+func lengthBudgetLeft(maxArguments, lengths int) bool {
+	return maxArguments <= 0 || lengths < scaleArgumentLimit(maxArguments, MaxEntriesPerArgument)
+}
+
+// jsonLimitError returns the limit an entry of n decoded bytes would breach,
+// given the number of arguments already stored, or nil when the entry fits.
+func jsonLimitError(n, maxArguments, args int, budget *int) error {
+	if maxArguments > 0 && args >= maxArguments {
+		return ErrArgumentsLimit
+	}
+	if n > *budget {
+		return ErrJSONDecodedSize
+	}
+	return nil
+}
+
+func (js *jsonBodyProcessor) ProcessResponse(reader io.Reader, v plugintypes.TransactionVariables, bpo plugintypes.BodyProcessorOptions) error {
 	// Read the entire body to store it and process it
 	s := strings.Builder{}
 	if _, err := io.Copy(&s, reader); err != nil {
 		return err
 	}
 	ss := s.String()
-	// Process with no recursion limit as we don't have a directive for response body
+
+	// Store the raw JSON in the TX variable for validateSchema before parsing,
+	// so operators like @validateSchema keep their data even when parsing stops
+	// early on the argument limit or the recursion-depth limit.
+	// This is needed because ResponseBody is a Single interface without a Set method
+	if txVar := v.TX(); txVar != nil && v.ResponseBody() != nil {
+		txVar.Set("json_response_body", []string{ss})
+	}
+
 	col := v.ResponseArgs()
-	data, err := readJSON(ss, ignoreJSONRecursionLimit)
-	if err != nil {
+	// The recursion limit protects against deeply nested bodies exhausting the
+	// stack; a non-positive value means unlimited.
+	depth := bpo.RequestBodyRecursionLimit
+	if depth <= 0 {
+		depth = ignoreJSONRecursionLimit
+	}
+	data, err := readJSON(ss, depth, bpo.ArgumentLimit)
+	if err != nil && !errors.Is(err, ErrArgumentsLimit) {
 		return err
 	}
 	for key, value := range data {
 		col.SetIndex(key, 0, value)
 	}
 
-	// Store the raw JSON in the TX variable for validateSchema
-	// This is needed because ResponseBody is a Single interface without a Set method
-	if txVar := v.TX(); txVar != nil && v.ResponseBody() != nil {
-		// Store the content type and raw body
-		txVar.Set("json_response_body", []string{ss})
-	}
-
-	return nil
+	return err
 }
 
-func readJSON(s string, maxRecursion int) (map[string]string, error) {
+func readJSON(s string, maxRecursion int, maxArguments int) (map[string]string, error) {
 	res := make(map[string]string)
 	key := []byte("json")
 
@@ -84,24 +175,37 @@ func readJSON(s string, maxRecursion int) (map[string]string, error) {
 		return res, errors.New("invalid JSON")
 	}
 	json := gjson.Parse(s)
-	err := readItems(json, key, maxRecursion, res)
+	budget := jsonDecodedBudget(len(s))
+	args := 0
+	lengths := 0
+	err := readItems(json, key, maxRecursion, maxArguments, &args, &lengths, &budget, res)
 	return res, err
 }
 
 // Transform JSON to a map[string]string
 // This function is recursive and will call itself for nested objects.
-// The limit in recursion is defined by maxItems.
+// Nesting is bounded by maxRecursion, the number of scalar values stored in
+// res is counted in args and bounded by maxArguments (<= 0 means unlimited),
+// and the total bytes stored (flattened keys plus values) are bounded by
+// budget, which is decremented as entries are added. The array-length entry
+// recorded for a non-empty array is not counted in args, because ModSecurity
+// counts scalar values alone as arguments; those entries are counted in lengths
+// and bounded by maxArguments scaled by MaxEntriesPerArgument, and exhausting
+// that budget drops further lengths without stopping the parse. When
+// maxArguments or budget is reached, parsing stops and ErrArgumentsLimit, or an
+// error wrapping it, is returned with the entries collected so far; exceeding
+// maxRecursion returns ErrJSONRecursionLimit instead.
 // Example input: {"data": {"name": "John", "age": 30}, "items": [1,2,3]}
 // Example output: map[string]string{"json.data.name": "John", "json.data.age": "30", "json.items.0": "1", "json.items.1": "2", "json.items.2": "3"}
 // Example input: [{"data": {"name": "John", "age": 30}, "items": [1,2,3]}]
 // Example output: map[string]string{"json.0.data.name": "John", "json.0.data.age": "30", "json.0.items.0": "1", "json.0.items.1": "2", "json.0.items.2": "3"}
-func readItems(json gjson.Result, objKey []byte, maxRecursion int, res map[string]string) error {
+func readItems(json gjson.Result, objKey []byte, maxRecursion int, maxArguments int, args *int, lengths *int, budget *int, res map[string]string) error {
 	arrayLen := 0
 	var iterationError error
 	if maxRecursion == 0 {
 		// We reached the limit of nesting we want to handle. This protects against
 		// DoS attacks using deeply nested JSON structures (e.g., {"a":{"a":{"a":...}}}).
-		return errors.New("max recursion reached while reading json object")
+		return ErrJSONRecursionLimit
 	}
 	json.ForEach(func(key, value gjson.Result) bool {
 		// Avoid string concatenation to maintain a single buffer for key aggregation.
@@ -118,12 +222,9 @@ func readItems(json gjson.Result, objKey []byte, maxRecursion int, res map[strin
 		switch value.Type {
 		case gjson.JSON:
 			// call recursively with one less item to avoid doing infinite recursion
-			iterationError = readItems(value, objKey, maxRecursion-1, res)
-			if iterationError != nil {
-				return false
-			}
+			iterationError = readItems(value, objKey, maxRecursion-1, maxArguments, args, lengths, budget, res)
 			objKey = objKey[:prevParentLength]
-			return true
+			return iterationError == nil
 		case gjson.String:
 			val = value.Str
 		case gjson.Null:
@@ -133,13 +234,34 @@ func readItems(json gjson.Result, objKey []byte, maxRecursion int, res map[strin
 			val = value.Raw
 		}
 
+		if err := jsonLimitError(len(objKey)+len(val), maxArguments, *args, budget); err != nil {
+			iterationError = err
+			objKey = objKey[:prevParentLength]
+			return false
+		}
+		*budget -= len(objKey) + len(val)
+		*args++
 		res[string(objKey)] = val
 		objKey = objKey[:prevParentLength]
 
 		return true
 	})
-	if arrayLen > 0 {
-		res[string(objKey)] = strconv.Itoa(arrayLen)
+	// An iteration that stopped early never reached the remaining elements, so
+	// arrayLen understates the array and no length is recorded for it.
+	// Exhausting either budget drops the entry and lets the parse continue
+	// rather than reporting a truncation. A document can hold more arrays than
+	// it holds arguments, so failing here would deny bodies that carry no
+	// arguments at all, and no portable rule can read what is dropped: neither
+	// ModSecurity version records an array length, so a rule selecting one
+	// would not load on the engines this corpus also targets. Dropping still
+	// bounds what is stored, because an entry is only written while it fits.
+	if arrayLen > 0 && iterationError == nil && lengthBudgetLeft(maxArguments, *lengths) {
+		arrayLenVal := strconv.Itoa(arrayLen)
+		if n := len(objKey) + len(arrayLenVal); n <= *budget {
+			*budget -= n
+			*lengths++
+			res[string(objKey)] = arrayLenVal
+		}
 	}
 	return iterationError
 }

--- a/internal/bodyprocessors/json_test.go
+++ b/internal/bodyprocessors/json_test.go
@@ -5,6 +5,9 @@ package bodyprocessors
 
 import (
 	"errors"
+	"fmt"
+	"math"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -183,7 +186,7 @@ func TestReadJSON(t *testing.T) {
 	for _, tc := range jsonTests {
 		tt := tc
 		t.Run(tt.name, func(t *testing.T) {
-			jsonMap, err := readJSON(tt.json, maxRecursion)
+			jsonMap, err := readJSON(tt.json, maxRecursion, 0)
 
 			// Special case for nested_empty - just check that the function doesn't error
 			if tt.name == "nested_empty" {
@@ -230,7 +233,7 @@ func mapKeys(m map[string]string) []string {
 }
 
 func TestInvalidJSON(t *testing.T) {
-	_, err := readJSON(`{invalid json`, maxRecursion)
+	_, err := readJSON(`{invalid json`, maxRecursion, 0)
 	if err == nil {
 		// We expect an error for invalid JSON since we now validate
 		t.Error("Expected error for invalid JSON, got nil")
@@ -242,7 +245,7 @@ func BenchmarkReadJSON(b *testing.B) {
 		tt := tc
 		b.Run(tt.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				_, err := readJSON(tt.json, maxRecursion)
+				_, err := readJSON(tt.json, maxRecursion, 0)
 				if err != nil {
 					b.Error(err)
 				}
@@ -257,7 +260,10 @@ func readJSONNoValidation(s string, maxRecursion int) (map[string]string, error)
 	json := gjson.Parse(s)
 	res := make(map[string]string)
 	key := []byte("json")
-	err := readItems(json, key, maxRecursion, res)
+	budget := len(s) + jsonDecodedBytesSlack
+	args := 0
+	lengths := 0
+	err := readItems(json, key, maxRecursion, 0, &args, &lengths, &budget, res)
 	return res, err
 }
 
@@ -303,7 +309,7 @@ func BenchmarkValidationOverhead(b *testing.B) {
 		b.Run("WithValidation/"+bc.name, func(b *testing.B) {
 			b.SetBytes(int64(len(bc.json)))
 			for i := 0; i < b.N; i++ {
-				if _, err := readJSON(bc.json, maxRecursion); err != nil {
+				if _, err := readJSON(bc.json, maxRecursion, 0); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -314,6 +320,70 @@ func BenchmarkValidationOverhead(b *testing.B) {
 				if _, err := readJSONNoValidation(bc.json, maxRecursion); err != nil {
 					b.Fatal(err)
 				}
+			}
+		})
+	}
+}
+
+// TestReadJSONArgumentsLimitAllocs asserts that readJSON stops flattening as
+// soon as the argument limit is reached: on a ~100k-member body with a limit
+// of 10 the allocation volume must stay in the KiB range, not scale with the
+// body.
+func TestReadJSONArgumentsLimitAllocs(t *testing.T) {
+	body := strings.Builder{}
+	body.WriteString("{")
+	for i := 0; i < 100000; i++ {
+		if i > 0 {
+			body.WriteString(",")
+		}
+		fmt.Fprintf(&body, `"key%06d":"value"`, i)
+	}
+	body.WriteString("}")
+	s := body.String()
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	res, err := readJSON(s, maxRecursion, 10)
+	runtime.ReadMemStats(&after)
+
+	if !errors.Is(err, ErrArgumentsLimit) {
+		t.Fatalf("expected ErrArgumentsLimit, got %v", err)
+	}
+	if want, have := 10, len(res); want != have {
+		t.Fatalf("unexpected number of members, want %d, have %d", want, have)
+	}
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > 256<<10 {
+		t.Errorf("allocated %d bytes, expected at most %d", allocated, 256<<10)
+	}
+}
+
+// TestJSONDecodedBudget asserts the decoded-bytes budget a body earns: small
+// bodies earn a multiple of their own size, large ones stop at the ceiling, and
+// the multiplication is never allowed to wrap on a 32-bit target.
+func TestJSONDecodedBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		n    int
+		want int
+	}{
+		{name: "empty", n: 0, want: 0},
+		{name: "small_scales", n: 1000, want: 1000 + 1000*jsonDecodedBytesScale},
+		{name: "at_the_ceiling", n: jsonDecodedBytesSlack / jsonDecodedBytesScale, want: jsonDecodedBytesSlack/jsonDecodedBytesScale + jsonDecodedBytesSlack},
+		{name: "past_the_ceiling", n: 1 << 24, want: 1<<24 + jsonDecodedBytesSlack},
+		{name: "would_overflow", n: math.MaxInt/jsonDecodedBytesScale + 1, want: math.MaxInt/jsonDecodedBytesScale + 1 + jsonDecodedBytesSlack},
+		// n*jsonDecodedBytesScale wraps to a small positive value here, which
+		// would starve the budget rather than widen it, so it must be caught as
+		// surely as a product that wraps negative. The expression picks such an
+		// n at whatever width int has.
+		{name: "would_overflow_to_small_positive", n: math.MaxInt>>5 + 2, want: math.MaxInt>>5 + 2 + jsonDecodedBytesSlack},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if have := jsonDecodedBudget(tc.n); have != tc.want {
+				t.Errorf("unexpected budget for a %d byte body, want %d, have %d", tc.n, tc.want, have)
+			}
+			if jsonDecodedBudget(tc.n) < tc.n {
+				t.Errorf("budget for a %d byte body is below the body itself", tc.n)
 			}
 		})
 	}

--- a/internal/bodyprocessors/multipart.go
+++ b/internal/bodyprocessors/multipart.go
@@ -7,15 +7,26 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"mime/multipart"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/collections"
 	"github.com/corazawaf/coraza/v3/internal/environment"
 )
+
+// MaxHeadersPerPart is the number of headers a legitimate multipart part is
+// expected to carry: Content-Disposition, Content-Type and
+// Content-Transfer-Encoding, plus margin for the uncommon ones a client may
+// add. It scales the argument limit into the budget MULTIPART_PART_HEADERS
+// gets, keeping the budget out of reach of ordinary forms while a header flood,
+// which Go's multipart reader admits up to 10000 of per part, still exhausts
+// it.
+const MaxHeadersPerPart = 8
 
 type multipartBodyProcessor struct{}
 
@@ -39,6 +50,25 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 	filesCombinedSizeCol := v.FilesCombinedSize()
 	filesNamesCol := v.FilesNames()
 	headersNames := v.MultipartPartHeaders()
+	// The argument budget covers the members that carry attacker-supplied
+	// values, one per part: a field part costs its ARGS_POST value, and a file
+	// part costs one member for FILES, FILES_NAMES, FILES_SIZES and
+	// FILES_TMP_NAMES together, which are four views of the same part whose
+	// combined size SecRequestBodyLimit already bounds. ModSecurity charges file
+	// parts nothing at all. The budget is checked before reading a part's body,
+	// so over-budget parts are never buffered and never create temp files.
+	// Part-header count is attacker-controlled and independent of argument
+	// content, so MULTIPART_PART_HEADERS gets its own separate budget: the
+	// argument limit scaled by MaxHeadersPerPart, so a form whose parts fit the
+	// argument budget cannot reach it. Exhausting it stops recording further
+	// headers but never aborts the parse, so a part-header flood cannot empty
+	// the argument collections; the parse then reports ErrArgumentsLimit so the
+	// truncation is visible to the rules.
+	limit := options.ArgumentLimit
+	headerLimit := scaleArgumentLimit(limit, MaxHeadersPerPart)
+	members := 0
+	headerMembers := 0
+	headersOverLimit := false
 	for {
 		p, err := mr.NextPart()
 		if err == io.EOF {
@@ -49,11 +79,22 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 			return err
 		}
 		partName := p.FormName()
-		for key, values := range p.Header {
-			for _, value := range values {
+		// Sorted so that the headers a part keeps when the budget runs out are a
+		// stable prefix rather than whichever ones the map happened to yield.
+		for _, key := range slices.Sorted(maps.Keys(p.Header)) {
+			for _, value := range p.Header[key] {
+				if limit > 0 && headerMembers >= headerLimit {
+					headersOverLimit = true
+					break
+				}
 				headersNames.Add(partName, fmt.Sprintf("%s: %s", key, value))
+				headerMembers++
 			}
 		}
+		if limit > 0 && members >= limit {
+			return ErrArgumentsLimit
+		}
+		members++
 		// if is a file
 		filename := originFileName(p)
 		if filename != "" {
@@ -66,8 +107,13 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 					v.MultipartStrictError().(*collections.Single).Set("1")
 					return err
 				}
-				defer temp.Close()
 				sz, err := io.Copy(temp, p)
+				if cerr := temp.Close(); cerr != nil && err == nil {
+					err = cerr
+				}
+				// Registered before any error return so that the transaction
+				// cleanup, which walks FILES_TMP_NAMES, still removes the file.
+				filesTmpNamesCol.Add("", temp.Name())
 				if err != nil {
 					if !errors.Is(err, io.ErrUnexpectedEOF) {
 						v.MultipartStrictError().(*collections.Single).Set("1")
@@ -76,7 +122,6 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 					seenUnexpectedEOF = true
 				}
 				size = sz
-				filesTmpNamesCol.Add("", temp.Name())
 			} else {
 				sz, err := io.Copy(io.Discard, p)
 				if err != nil {
@@ -112,6 +157,9 @@ func (mbp *multipartBodyProcessor) ProcessRequest(reader io.Reader, v plugintype
 				break
 			}
 		}
+	}
+	if headersOverLimit {
+		return ErrArgumentsLimit
 	}
 	return nil
 }

--- a/internal/bodyprocessors/urlencoded.go
+++ b/internal/bodyprocessors/urlencoded.go
@@ -23,13 +23,27 @@ func (*urlencodedBodyProcessor) ProcessRequest(reader io.Reader, v plugintypes.T
 	}
 
 	b := buf.String()
-	values := urlutil.ParseQuery(b, '&')
-	argsCol := v.ArgsPost()
-	for k, vs := range values {
-		argsCol.Set(k, vs)
-	}
 	v.RequestBody().(*collections.Single).Set(b)
 	v.RequestBodyLength().(*collections.Single).Set(strconv.Itoa(len(b)))
+	// Arguments are decoded in document order straight into ARGS_POST, so the
+	// limit truncates deterministically and arguments past it are never
+	// decoded.
+	argsCol := v.ArgsPost()
+	limit := options.ArgumentLimit
+	count := 0
+	overLimit := false
+	urlutil.EachQueryValue(b, '&', func(key, value string) bool {
+		if limit > 0 && count >= limit {
+			overLimit = true
+			return false
+		}
+		argsCol.Add(key, value)
+		count++
+		return true
+	})
+	if overLimit {
+		return ErrArgumentsLimit
+	}
 	return nil
 }
 

--- a/internal/bodyprocessors/xml.go
+++ b/internal/bodyprocessors/xml.go
@@ -12,25 +12,41 @@ import (
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 )
 
+// MaxNodesPerArgument is the number of REQUEST_XML members a document spends on
+// the information a form carries in a single argument: a field becomes an
+// element with a text node plus the attributes that type or namespace it, and
+// the records holding those fields sit inside envelope, header and list
+// elements that contribute members of their own. It scales the argument limit
+// into the budget REQUEST_XML gets, so documents of a few thousand nodes parse
+// whole under a limit tuned for form fields while a node flood still exhausts
+// it. ModSecurity charges XML nothing at all: it ignores attributes and adds
+// text nodes only under SecParseXmlIntoArgs, which is off by default. Coraza
+// always populates REQUEST_XML, so the budget is what bounds the collection.
+const MaxNodesPerArgument = 16
+
 type xmlBodyProcessor struct {
 }
 
 func (*xmlBodyProcessor) ProcessRequest(reader io.Reader, v plugintypes.TransactionVariables, options plugintypes.BodyProcessorOptions) error {
-	values, contents, err := readXML(reader)
-	if err != nil {
+	values, contents, err := readXML(reader, scaleArgumentLimit(options.ArgumentLimit, MaxNodesPerArgument))
+	if err != nil && !errors.Is(err, ErrArgumentsLimit) {
 		return err
 	}
 	col := v.RequestXML()
 	col.Set("//@*", values)
 	col.Set("/*", contents)
-	return nil
+	return err
 }
 
 func (*xmlBodyProcessor) ProcessResponse(reader io.Reader, v plugintypes.TransactionVariables, options plugintypes.BodyProcessorOptions) error {
 	return nil
 }
 
-func readXML(reader io.Reader) ([]string, []string, error) {
+// readXML extracts attribute values and element contents from an XML document.
+// Attributes and contents share a single budget of limit members (<= 0 means
+// unlimited); when it is exhausted, decoding stops and ErrArgumentsLimit is
+// returned along with the members collected so far.
+func readXML(reader io.Reader, limit int) ([]string, []string, error) {
 	var attrs []string
 	var content []string
 	dec := xml.NewDecoder(reader)
@@ -48,10 +64,16 @@ func readXML(reader io.Reader) ([]string, []string, error) {
 		switch tok := token.(type) {
 		case xml.StartElement:
 			for _, attr := range tok.Attr {
+				if limit > 0 && len(attrs)+len(content) >= limit {
+					return attrs, content, ErrArgumentsLimit
+				}
 				attrs = append(attrs, attr.Value)
 			}
 		case xml.CharData:
 			if c := strings.TrimSpace(string(tok)); c != "" {
+				if limit > 0 && len(attrs)+len(content) >= limit {
+					return attrs, content, ErrArgumentsLimit
+				}
 				content = append(content, c)
 			}
 		}

--- a/internal/bodyprocessors/xml_test.go
+++ b/internal/bodyprocessors/xml_test.go
@@ -24,7 +24,7 @@ func TestXMLAttribures(t *testing.T) {
 </book>
 
 </bookstore>`
-	attrs, contents, err := readXML(bytes.NewReader([]byte(xmldoc)))
+	attrs, contents, err := readXML(bytes.NewReader([]byte(xmldoc)), 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -55,7 +55,7 @@ func TestXMLPayloadFlexibility(t *testing.T) {
 			<heading>Reminder</heading>
 			<body>Don't forget me this weekend!
 		</note>`
-	_, contents, err := readXML(bytes.NewReader([]byte(xmldoc)))
+	_, contents, err := readXML(bytes.NewReader([]byte(xmldoc)), 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -105,7 +105,7 @@ func TestXMLUnexpectedEOF(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			xmldoc := tc.Input
-			_, contents, err := readXML(bytes.NewReader([]byte(xmldoc)))
+			_, contents, err := readXML(bytes.NewReader([]byte(xmldoc)), 0)
 			if err != nil {
 				t.Error(err)
 			}

--- a/internal/collections/map.go
+++ b/internal/collections/map.go
@@ -17,7 +17,10 @@ import (
 type Map struct {
 	isCaseSensitive bool
 	data            map[string][]keyValue
-	variable        variables.RuleVariable
+	// valueCount is the total number of values held across every key. It is
+	// maintained by the mutators so that Len is O(1) on the argument path.
+	valueCount int
+	variable   variables.RuleVariable
 }
 
 var _ collection.Map = &Map{}
@@ -150,6 +153,7 @@ func (c *Map) Add(key string, value string) {
 		key = strings.ToLower(key)
 	}
 	c.data[key] = append(c.data[key], aVal)
+	c.valueCount++
 }
 
 // Sets the value of a key with the array of strings passed. If the key already exists, it will be overwritten.
@@ -159,6 +163,7 @@ func (c *Map) Set(key string, values []string) {
 		key = strings.ToLower(key)
 	}
 	dataSlice, exists := c.data[key]
+	c.valueCount += len(values) - len(dataSlice)
 	if !exists || cap(dataSlice) < len(values) {
 		dataSlice = make([]keyValue, len(values))
 	} else {
@@ -182,8 +187,10 @@ func (c *Map) SetIndex(key string, index int, value string) {
 	switch {
 	case len(values) == 0:
 		c.data[key] = []keyValue{av}
+		c.valueCount++
 	case len(values) <= index:
 		c.data[key] = append(c.data[key], av)
+		c.valueCount++
 	default:
 		c.data[key][index] = av
 	}
@@ -197,6 +204,7 @@ func (c *Map) Remove(key string) {
 	if len(c.data) == 0 {
 		return
 	}
+	c.valueCount -= len(c.data[key])
 	delete(c.data, key)
 }
 
@@ -210,6 +218,7 @@ func (c *Map) Reset() {
 	for k := range c.data {
 		delete(c.data, k)
 	}
+	c.valueCount = 0
 }
 
 // Format updates the passed strings.Builder with the formatted map key/values.
@@ -237,9 +246,10 @@ func (c *Map) String() string {
 	return res.String()
 }
 
-// Len returns the number of key/value pairs in the map.
+// Len returns the number of values held in the map, counting each value of a
+// repeated key, the way ModSecurity counts argument table entries.
 func (c *Map) Len() int {
-	return len(c.data)
+	return c.valueCount
 }
 
 // keyValue stores the case preserved original key and value

--- a/internal/collections/map_test.go
+++ b/internal/collections/map_test.go
@@ -58,8 +58,8 @@ func TestMap(t *testing.T) {
 		}
 	}
 
-	if c.Len() != len(c.data) {
-		t.Fatal("The lengths are not equal.")
+	if want, have := len(c.FindAll()), c.Len(); want != have {
+		t.Fatalf("%d values are stored, Len reports %d", want, have)
 	}
 
 }
@@ -101,8 +101,8 @@ func TestNewCaseSensitiveKeyMap(t *testing.T) {
 		}
 	}
 
-	if c.Len() != len(c.data) {
-		t.Fatal("The lengths are not equal.")
+	if want, have := len(c.FindAll()), c.Len(); want != have {
+		t.Fatalf("%d values are stored, Len reports %d", want, have)
 	}
 
 }
@@ -241,4 +241,36 @@ func BenchmarkTxSetGet(b *testing.B) {
 		}
 	})
 	b.ReportAllocs()
+}
+
+// TestMapLenCountsStoredValues asserts that Len counts stored values, one per
+// key/value pair as ModSecurity counts argument table entries, and that the
+// count stays exact across every mutator. FindAll enumerates the stored values,
+// so it is the oracle Len has to agree with.
+func TestMapLenCountsStoredValues(t *testing.T) {
+	c := NewMap(variables.ArgsGet)
+	for _, step := range []struct {
+		name string
+		op   func()
+	}{
+		{"add", func() { c.Add("a", "1") }},
+		{"add repeated key", func() { c.Add("a", "2") }},
+		{"add another key", func() { c.Add("b", "1") }},
+		{"set replaces with a shorter list", func() { c.Set("a", []string{"x"}) }},
+		{"set replaces with a longer list", func() { c.Set("a", []string{"x", "y", "z"}) }},
+		{"set a new key", func() { c.Set("c", []string{"1", "2"}) }},
+		{"set an empty list", func() { c.Set("c", nil) }},
+		{"set index over an existing value", func() { c.SetIndex("a", 1, "w") }},
+		{"set index past the end appends", func() { c.SetIndex("a", 9, "v") }},
+		{"set index on a new key", func() { c.SetIndex("d", 0, "v") }},
+		{"remove a multi value key", func() { c.Remove("a") }},
+		{"remove a key that is not there", func() { c.Remove("zz") }},
+		{"reset", func() { c.Reset() }},
+		{"add after reset", func() { c.Add("a", "1") }},
+	} {
+		step.op()
+		if want, have := len(c.FindAll()), c.Len(); want != have {
+			t.Fatalf("after %s: %d values are stored, Len reports %d", step.name, want, have)
+		}
+	}
 }

--- a/internal/collections/maplen_prop_test.go
+++ b/internal/collections/maplen_prop_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 CloudLinux
+// SPDX-License-Identifier: Apache-2.0
+
+package collections
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/corazawaf/coraza/v3/types/variables"
+)
+
+// keys chosen so the case-insensitive map collides two distinct input keys onto
+// one stored key, and so Remove sometimes targets an absent key.
+var propKeys = []string{"a", "A", "b", "B", "cc", "CC", "absent", "zZ"}
+
+func groundTruth(c *Map) int { return len(c.FindAll()) }
+
+func randValues(r *rand.Rand) []string {
+	switch r.Intn(4) {
+	case 0:
+		return nil
+	case 1:
+		return []string{}
+	default:
+		n := r.Intn(5)
+		vs := make([]string, n)
+		for i := range vs {
+			vs[i] = fmt.Sprintf("v%d", i)
+		}
+		return vs
+	}
+}
+
+func runPropSeq(t *testing.T, c *Map, r *rand.Rand, steps int) {
+	t.Helper()
+	for i := 0; i < steps; i++ {
+		k := propKeys[r.Intn(len(propKeys))]
+		var op string
+		switch r.Intn(6) {
+		case 0:
+			op = fmt.Sprintf("Add(%q)", k)
+			c.Add(k, "x")
+		case 1:
+			vs := randValues(r)
+			op = fmt.Sprintf("Set(%q, %v)", k, vs)
+			c.Set(k, vs)
+		case 2:
+			// index 0 / at len / past len / far past len
+			cur := len(c.Get(k))
+			idx := []int{0, cur, cur + 1, cur + 50}[r.Intn(4)]
+			op = fmt.Sprintf("SetIndex(%q, %d)", k, idx)
+			c.SetIndex(k, idx, "y")
+		case 3:
+			op = fmt.Sprintf("Remove(%q)", k)
+			c.Remove(k)
+		case 4:
+			op = "Reset()"
+			c.Reset()
+		case 5:
+			// churn: add then set shorter, exercising cap-reuse branch in Set
+			c.Add(k, "p")
+			c.Add(k, "q")
+			c.Set(k, []string{"r"})
+			op = fmt.Sprintf("Add+Add+Set-shorter(%q)", k)
+		}
+		if want, have := groundTruth(c), c.Len(); want != have {
+			t.Fatalf("step %d after %s: stored=%d Len=%d (data=%v)", i, op, want, have, c.data)
+		}
+	}
+}
+
+func TestPropMapLenMatchesStoredValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mk   func() *Map
+	}{
+		{"case-insensitive", func() *Map { return NewMap(variables.ArgsGet) }},
+		{"case-sensitive", func() *Map { return NewCaseSensitiveKeyMap(variables.ArgsGet) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for seed := int64(0); seed < 500; seed++ {
+				c := tc.mk()
+				runPropSeq(t, c, rand.New(rand.NewSource(seed)), 400)
+			}
+		})
+	}
+}
+
+func TestPropNamedCollectionLenMatchesStoredValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mk   func() *NamedCollection
+	}{
+		{"case-insensitive", func() *NamedCollection { return NewNamedCollection(variables.ArgsGet) }},
+		{"case-sensitive", func() *NamedCollection { return NewCaseSensitiveNamedCollection(variables.ArgsGet) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for seed := int64(0); seed < 500; seed++ {
+				c := tc.mk()
+				runPropSeq(t, c.Map, rand.New(rand.NewSource(seed)), 400)
+			}
+		})
+	}
+}
+
+// Named edge cases that the random walk may under-sample.
+func TestMapLenEdgeCases(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(c *Map)
+	}{
+		{"remove on empty map", func(c *Map) { c.Remove("nope") }},
+		{"remove absent key with entries", func(c *Map) { c.Add("a", "1"); c.Remove("nope") }},
+		{"set empty slice on new key", func(c *Map) { c.Set("a", []string{}) }},
+		{"set nil on existing key", func(c *Map) { c.Add("a", "1"); c.Set("a", nil) }},
+		{"set shorter then longer", func(c *Map) {
+			c.Set("a", []string{"1", "2", "3"})
+			c.Set("a", []string{"1"})
+			c.Set("a", []string{"1", "2", "3", "4"})
+		}},
+		{"setindex 0 on empty", func(c *Map) { c.SetIndex("a", 0, "v") }},
+		{"setindex at len", func(c *Map) { c.Add("a", "1"); c.SetIndex("a", 1, "v") }},
+		{"setindex far past len", func(c *Map) { c.Add("a", "1"); c.SetIndex("a", 99, "v") }},
+		{"setindex overwrite", func(c *Map) { c.Add("a", "1"); c.SetIndex("a", 0, "v") }},
+		{"case collision add", func(c *Map) { c.Add("Key", "1"); c.Add("kEy", "2"); c.Add("KEY", "3") }},
+		{"case collision set then remove", func(c *Map) {
+			c.Add("Key", "1")
+			c.Set("kEy", []string{"a", "b"})
+			c.Remove("KEY")
+		}},
+		{"case collision setindex", func(c *Map) { c.Add("Key", "1"); c.SetIndex("kEy", 5, "z") }},
+		{"reset then reuse", func(c *Map) {
+			c.Add("a", "1")
+			c.Add("b", "2")
+			c.Reset()
+			c.Add("a", "1")
+			c.Set("b", []string{"1", "2"})
+		}},
+		{"remove after set-empty", func(c *Map) { c.Set("a", nil); c.Remove("a") }},
+	} {
+		for _, cs := range []struct {
+			name string
+			mk   func() *Map
+		}{
+			{"ci", func() *Map { return NewMap(variables.ArgsGet) }},
+			{"cs", func() *Map { return NewCaseSensitiveKeyMap(variables.ArgsGet) }},
+		} {
+			t.Run(tc.name+"/"+cs.name, func(t *testing.T) {
+				c := cs.mk()
+				tc.run(c)
+				if want, have := groundTruth(c), c.Len(); want != have {
+					t.Fatalf("stored=%d Len=%d (data=%v)", want, have, c.data)
+				}
+			})
+		}
+	}
+}
+
+// FuzzMapLen drives the same invariant from a fuzzer-controlled opcode stream.
+func FuzzMapLen(f *testing.F) {
+	f.Add([]byte{0, 1, 2, 3, 4, 5})
+	f.Add([]byte{1, 0, 0, 3, 2, 2, 2})
+	f.Fuzz(func(t *testing.T, ops []byte) {
+		for _, c := range []*Map{NewMap(variables.ArgsGet), NewCaseSensitiveKeyMap(variables.ArgsGet)} {
+			for i := 0; i+1 < len(ops); i += 2 {
+				k := propKeys[int(ops[i+1])%len(propKeys)]
+				switch ops[i] % 6 {
+				case 0:
+					c.Add(k, "x")
+				case 1:
+					c.Set(k, make([]string, int(ops[i+1])%4))
+				case 2:
+					c.SetIndex(k, int(ops[i+1])%5, "y")
+				case 3:
+					c.Remove(k)
+				case 4:
+					c.Reset()
+				case 5:
+					c.Set(k, nil)
+				}
+				if want, have := groundTruth(c), c.Len(); want != have {
+					t.Fatalf("op %d key %q: stored=%d Len=%d", ops[i]%6, k, want, have)
+				}
+			}
+		}
+	})
+}

--- a/internal/collections/named.go
+++ b/internal/collections/named.go
@@ -55,10 +55,6 @@ func (c *NamedCollection) Remove(key string) {
 	c.Map.Remove(key)
 }
 
-func (c *NamedCollection) Len() int {
-	return len(c.data)
-}
-
 // Data is an internal method used for serializing to JSON
 func (c *NamedCollection) Data() map[string][]string {
 	result := make(map[string][]string, len(c.data))

--- a/internal/collections/named_test.go
+++ b/internal/collections/named_test.go
@@ -82,8 +82,8 @@ func TestNamedCollection(t *testing.T) {
 		t.Errorf("want %q, have %q", want, have)
 	}
 
-	if c.Len() != len(c.data) {
-		t.Fatal("The lengths are not equal.")
+	if want, have := len(c.FindAll()), c.Len(); want != have {
+		t.Fatalf("%d values are stored, Len reports %d", want, have)
 	}
 
 }

--- a/internal/corazawaf/rule_multiphase.go
+++ b/internal/corazawaf/rule_multiphase.go
@@ -126,6 +126,8 @@ func minPhase(v variables.RuleVariable) types.RulePhase {
 		return types.PhaseRequestHeaders
 	case variables.RequestURIRaw:
 		return types.PhaseRequestHeaders
+	case variables.ResBodyError, variables.ResBodyErrorMsg, variables.ResBodyProcessorError, variables.ResBodyProcessorErrorMsg:
+		return types.PhaseResponseBody
 	case variables.ResponseBody:
 		return types.PhaseResponseBody
 	case variables.ResponseContentLength:

--- a/internal/corazawaf/rulegroup.go
+++ b/internal/corazawaf/rulegroup.go
@@ -263,7 +263,9 @@ RulesLoop:
 		}
 		// Reset matched_vars only when the previous rule actually populated it.
 		// In typical CRS evaluation most rules don't match, so this avoids
-		// iterating an empty map on every rule.
+		// iterating an empty map on every rule. Len counts stored values, so
+		// this is only a sound emptiness test while Add stays the collection's
+		// sole writer: Set would leave a valueless key that Len does not see.
 		if tx.variables.matchedVars.Len() > 0 {
 			tx.variables.matchedVars.Reset()
 		}

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -225,6 +225,14 @@ func (tx *Transaction) Collection(idx variables.RuleVariable) collection.Collect
 		return tx.variables.reqbodyProcessorErrorMsg
 	case variables.ReqbodyProcessor:
 		return tx.variables.reqbodyProcessor
+	case variables.ResBodyError:
+		return tx.variables.resBodyError
+	case variables.ResBodyErrorMsg:
+		return tx.variables.resBodyErrorMsg
+	case variables.ResBodyProcessorError:
+		return tx.variables.resBodyProcessorError
+	case variables.ResBodyProcessorErrorMsg:
+		return tx.variables.resBodyProcessorErrorMsg
 	case variables.RequestBasename:
 		return tx.variables.requestBasename
 	case variables.RequestBody:
@@ -811,19 +819,23 @@ func (tx *Transaction) ProcessConnection(client string, cPort int, server string
 	tx.variables.serverPort.Set(p2)
 }
 
-// ExtractGetArguments transforms an url encoded string to a map and creates ARGS_GET
+// ExtractGetArguments decodes an url encoded query string into ARGS_GET in
+// document order, so which arguments survive the SecArgumentsLimit cut is
+// deterministic across requests.
 func (tx *Transaction) ExtractGetArguments(uri string) {
-	data := urlutil.ParseQuery(uri, '&')
-	for k, vs := range data {
-		for _, v := range vs {
-			tx.AddGetRequestArgument(k, v)
+	urlutil.EachQueryValue(uri, '&', func(k, v string) bool {
+		if tx.checkRequestArgumentLimit(tx.variables.argsGet) {
+			tx.debugLogger.Warn().Msg("skipping get request argument, over limit")
+			return false
 		}
-	}
+		tx.variables.argsGet.Add(k, v)
+		return true
+	})
 }
 
 // AddGetRequestArgument
 func (tx *Transaction) AddGetRequestArgument(key string, value string) {
-	if tx.checkArgumentLimit(tx.variables.argsGet) {
+	if tx.checkRequestArgumentLimit(tx.variables.argsGet) {
 		tx.debugLogger.Warn().Msg("skipping get request argument, over limit")
 		return
 	}
@@ -832,7 +844,7 @@ func (tx *Transaction) AddGetRequestArgument(key string, value string) {
 
 // AddPostRequestArgument
 func (tx *Transaction) AddPostRequestArgument(key string, value string) {
-	if tx.checkArgumentLimit(tx.variables.argsPost) {
+	if tx.checkRequestArgumentLimit(tx.variables.argsPost) {
 		tx.debugLogger.Warn().Msg("skipping post request argument, over limit")
 		return
 	}
@@ -841,20 +853,49 @@ func (tx *Transaction) AddPostRequestArgument(key string, value string) {
 
 // AddPathRequestArgument
 func (tx *Transaction) AddPathRequestArgument(key string, value string) {
-	if tx.checkArgumentLimit(tx.variables.argsPath) {
+	if tx.checkRequestArgumentLimit(tx.variables.argsPath) {
 		tx.debugLogger.Warn().Msg("skipping path request argument, over limit")
 		return
 	}
 	tx.variables.argsPath.Add(key, value)
 }
 
-func (tx *Transaction) checkArgumentLimit(c *collections.NamedCollection) bool {
-	return c.Len() >= tx.WAF.ArgumentLimit
+// argumentsLimitErrorMsg is the body error message a SecArgumentsLimit trip
+// reports, matching ModSecurity.
+const argumentsLimitErrorMsg = "SecArgumentsLimit exceeded"
+
+// signalArgumentsLimit raises the body error flag and message pair for a
+// SecArgumentsLimit trip. Once the flag is set the message is left alone.
+func signalArgumentsLimit(errorFlag, errorMsg *collections.Single) {
+	if errorFlag.Get() == "1" {
+		return
+	}
+	errorFlag.Set("1")
+	errorMsg.Set(argumentsLimitErrorMsg)
+}
+
+// checkArgumentLimit reports whether c has reached SecArgumentsLimit and, if it
+// has, raises the error flag and message pair covering c. Callers must stop
+// adding to c once it returns true.
+func (tx *Transaction) checkArgumentLimit(c interface{ Len() int }, errorFlag, errorMsg *collections.Single) bool {
+	if c.Len() < tx.WAF.ArgumentLimit {
+		return false
+	}
+	signalArgumentsLimit(errorFlag, errorMsg)
+	return true
+}
+
+// checkRequestArgumentLimit applies the limit to a request collection, so a
+// trip reports through REQBODY_ERROR.
+func (tx *Transaction) checkRequestArgumentLimit(c interface{ Len() int }) bool {
+	return tx.checkArgumentLimit(c, tx.variables.reqbodyError, tx.variables.reqbodyErrorMsg)
 }
 
 // AddResponseArgument
 func (tx *Transaction) AddResponseArgument(key string, value string) {
-	if tx.variables.responseArgs.Len() >= tx.WAF.ArgumentLimit {
+	// RESPONSE_ARGS is filled while the response is processed, so a trip
+	// reports through RES_BODY_ERROR rather than the request-side pair.
+	if tx.checkArgumentLimit(tx.variables.responseArgs, tx.variables.resBodyError, tx.variables.resBodyErrorMsg) {
 		tx.debugLogger.Warn().Msg("skipping response argument, over limit")
 		return
 	}
@@ -1187,9 +1228,22 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 		Mime:                      mimeType,
 		StoragePath:               tx.WAF.UploadDir,
 		RequestBodyRecursionLimit: tx.WAF.RequestBodyJsonDepthLimit,
+		ArgumentLimit:             tx.WAF.ArgumentLimit,
 	}); err != nil {
-		tx.debugLogger.Error().Err(err).Msg("Failed to process request body")
-		tx.generateRequestBodyError(err)
+		switch {
+		case errors.Is(err, bodyprocessors.ErrJSONDecodedSize), errors.Is(err, bodyprocessors.ErrJSONRecursionLimit):
+			// Limit trips on a syntactically valid body, so they log at the same
+			// level as the argument limit and only their rule-visible signal
+			// differs. Error is kept for bodies the parser could not read.
+			tx.debugLogger.Warn().Err(err).Msg("Failed to process request body")
+			tx.generateRequestBodyError(err)
+		case errors.Is(err, bodyprocessors.ErrArgumentsLimit):
+			tx.debugLogger.Warn().Msg("skipping request body arguments, over SecArgumentsLimit; inspection truncated")
+			signalArgumentsLimit(tx.variables.reqbodyError, tx.variables.reqbodyErrorMsg)
+		default:
+			tx.debugLogger.Error().Err(err).Msg("Failed to process request body")
+			tx.generateRequestBodyError(err)
+		}
 		tx.WAF.Rules.Eval(types.PhaseRequestBody, tx)
 		return tx.interruption, nil
 	}
@@ -1416,9 +1470,21 @@ func (tx *Transaction) ProcessResponseBody() (*types.Interruption, error) {
 		}
 
 		tx.debugLogger.Debug().Str("body_processor", bp).Msg("Attempting to process response body")
-		if err := b.ProcessResponse(reader, tx.Variables(), plugintypes.BodyProcessorOptions{}); err != nil {
-			tx.debugLogger.Error().Err(err).Msg("Failed to process response body")
-			tx.generateResponseBodyError(err)
+		if err := b.ProcessResponse(reader, tx.Variables(), plugintypes.BodyProcessorOptions{
+			RequestBodyRecursionLimit: tx.WAF.RequestBodyJsonDepthLimit,
+			ArgumentLimit:             tx.WAF.ArgumentLimit,
+		}); err != nil {
+			switch {
+			case errors.Is(err, bodyprocessors.ErrJSONDecodedSize), errors.Is(err, bodyprocessors.ErrJSONRecursionLimit):
+				tx.debugLogger.Warn().Err(err).Msg("Failed to process response body")
+				tx.generateResponseBodyError(err)
+			case errors.Is(err, bodyprocessors.ErrArgumentsLimit):
+				tx.debugLogger.Warn().Msg("skipping response body arguments, over SecArgumentsLimit; inspection truncated")
+				signalArgumentsLimit(tx.variables.resBodyError, tx.variables.resBodyErrorMsg)
+			default:
+				tx.debugLogger.Error().Err(err).Msg("Failed to process response body")
+				tx.generateResponseBodyError(err)
+			}
 		}
 	} else {
 		buf := new(strings.Builder)
@@ -2592,6 +2658,18 @@ func (v *TransactionVariables) All(f func(v variables.RuleVariable, col collecti
 		return
 	}
 	if !f(variables.ResBodyProcessor, v.resBodyProcessor) {
+		return
+	}
+	if !f(variables.ResBodyError, v.resBodyError) {
+		return
+	}
+	if !f(variables.ResBodyErrorMsg, v.resBodyErrorMsg) {
+		return
+	}
+	if !f(variables.ResBodyProcessorError, v.resBodyProcessorError) {
+		return
+	}
+	if !f(variables.ResBodyProcessorErrorMsg, v.resBodyProcessorErrorMsg) {
 		return
 	}
 	if !f(variables.Rule, v.rule) {

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -1830,6 +1830,14 @@ func (tx *Transaction) Close() error {
 	}
 
 	tx.variables.reset()
+	// Drop per-request references so the pooled transaction does not keep
+	// matched rules, transformed values or the other per-request state reachable
+	// until the transaction is reused.
+	tx.matchedRules = nil
+	tx.detectionOnlyInterruption = nil
+	tx.context = nil
+	tx.ruleFilter = nil
+	clear(tx.transformationCache)
 	if err := tx.requestBodyBuffer.Reset(); err != nil {
 		errs = append(errs, fmt.Errorf("reseting request body buffer: %v", err))
 	}

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/macro"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
+	"github.com/corazawaf/coraza/v3/internal/bodyprocessors"
 	"github.com/corazawaf/coraza/v3/internal/collections"
 	"github.com/corazawaf/coraza/v3/internal/corazarules"
 	"github.com/corazawaf/coraza/v3/internal/environment"
@@ -2102,6 +2103,413 @@ func TestAddGetArgsWithOverlimit(t *testing.T) {
 	}
 }
 
+// TestExtractGetArgumentsDeterministicTruncation asserts that when the query
+// string holds more distinct keys than SecArgumentsLimit, the same keys
+// survive on every run: arguments are consumed in document order rather than
+// Go map order, the trailing ones are dropped instead of stored, and
+// REQBODY_ERROR reports the cut.
+func TestExtractGetArgumentsDeterministicTruncation(t *testing.T) {
+	const uri = "evil=%3Cscript%3E&a=1&b=2&c=3&d=4"
+	for i := 0; i < 50; i++ {
+		waf := NewWAF()
+		waf.ArgumentLimit = 2
+		tx := waf.NewTransaction()
+		tx.ExtractGetArguments(uri)
+		if want, have := 1, len(tx.variables.argsGet.Get("evil")); want != have {
+			t.Fatalf("run %d: 'evil' not kept in document order, want %d value, have %d", i, want, have)
+		}
+		if want, have := 1, len(tx.variables.argsGet.Get("a")); want != have {
+			t.Fatalf("run %d: 'a' not kept in document order, want %d value, have %d", i, want, have)
+		}
+		if want, have := waf.ArgumentLimit, tx.variables.argsGet.Len(); want != have {
+			t.Fatalf("run %d: ARGS_GET must hold exactly the limit, want %d values, have %d", i, want, have)
+		}
+		for _, dropped := range []string{"b", "c", "d"} {
+			if have := tx.variables.argsGet.Get(dropped); len(have) != 0 {
+				t.Fatalf("run %d: %q is past the limit and must not be stored, have %v", i, dropped, have)
+			}
+		}
+		if want, have := "1", tx.variables.reqbodyError.Get(); want != have {
+			t.Fatalf("run %d: unexpected REQBODY_ERROR, want %q, have %q", i, want, have)
+		}
+		if want, have := argumentsLimitErrorMsg, tx.variables.reqbodyErrorMsg.Get(); want != have {
+			t.Fatalf("run %d: unexpected REQBODY_ERROR_MSG, want %q, have %q", i, want, have)
+		}
+		if err := tx.Close(); err != nil {
+			t.Fatalf("Failed to close transaction: %s", err.Error())
+		}
+	}
+}
+
+// TestArgumentsLimitCountsRepeatedKeys asserts that every value counts against
+// SecArgumentsLimit, not every distinct name. ModSecurity counts one argument
+// table entry per key=value pair, so a query string that stores all its values
+// under a single name is capped like any other.
+func TestArgumentsLimitCountsRepeatedKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fill func(tx *Transaction, values int)
+		get  func(tx *Transaction) []string
+	}{
+		{
+			name: "extract_get",
+			fill: func(tx *Transaction, values int) {
+				pairs := make([]string, 0, values)
+				for i := 0; i < values; i++ {
+					pairs = append(pairs, fmt.Sprintf("a=%d", i))
+				}
+				tx.ExtractGetArguments(strings.Join(pairs, "&"))
+			},
+			get: func(tx *Transaction) []string { return tx.variables.argsGet.Get("a") },
+		},
+		{
+			name: "add_get",
+			fill: func(tx *Transaction, values int) {
+				for i := 0; i < values; i++ {
+					tx.AddGetRequestArgument("a", strconv.Itoa(i))
+				}
+			},
+			get: func(tx *Transaction) []string { return tx.variables.argsGet.Get("a") },
+		},
+		{
+			name: "add_post",
+			fill: func(tx *Transaction, values int) {
+				for i := 0; i < values; i++ {
+					tx.AddPostRequestArgument("a", strconv.Itoa(i))
+				}
+			},
+			get: func(tx *Transaction) []string { return tx.variables.argsPost.Get("a") },
+		},
+		{
+			name: "add_path",
+			fill: func(tx *Transaction, values int) {
+				for i := 0; i < values; i++ {
+					tx.AddPathRequestArgument("a", strconv.Itoa(i))
+				}
+			},
+			get: func(tx *Transaction) []string { return tx.variables.argsPath.Get("a") },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			waf := NewWAF()
+			waf.ArgumentLimit = 3
+			tx := waf.NewTransaction()
+			tc.fill(tx, 10)
+			if want, have := waf.ArgumentLimit, len(tc.get(tx)); want != have {
+				t.Errorf("repeated key stored past the limit, want %d values, have %d", want, have)
+			}
+			if want, have := "1", tx.variables.reqbodyError.Get(); want != have {
+				t.Errorf("unexpected REQBODY_ERROR, want %q, have %q", want, have)
+			}
+			if want, have := argumentsLimitErrorMsg, tx.variables.reqbodyErrorMsg.Get(); want != have {
+				t.Errorf("unexpected REQBODY_ERROR_MSG, want %q, have %q", want, have)
+			}
+			if err := tx.Close(); err != nil {
+				t.Fatalf("Failed to close transaction: %s", err.Error())
+			}
+		})
+	}
+
+	t.Run("add_response", func(t *testing.T) {
+		waf := NewWAF()
+		waf.ArgumentLimit = 3
+		tx := waf.NewTransaction()
+		for i := 0; i < 10; i++ {
+			tx.AddResponseArgument("a", strconv.Itoa(i))
+		}
+		if want, have := waf.ArgumentLimit, len(tx.variables.responseArgs.Get("a")); want != have {
+			t.Errorf("repeated key stored past the limit, want %d values, have %d", want, have)
+		}
+		if want, have := "1", tx.variables.resBodyError.Get(); want != have {
+			t.Errorf("unexpected RES_BODY_ERROR, want %q, have %q", want, have)
+		}
+		if want, have := argumentsLimitErrorMsg, tx.variables.resBodyErrorMsg.Get(); want != have {
+			t.Errorf("unexpected RES_BODY_ERROR_MSG, want %q, have %q", want, have)
+		}
+		if err := tx.Close(); err != nil {
+			t.Fatalf("Failed to close transaction: %s", err.Error())
+		}
+	})
+}
+
+// queryString builds a url encoded query string holding keys distinct keys.
+func queryString(keys int) string {
+	pairs := make([]string, 0, keys)
+	for i := 0; i < keys; i++ {
+		pairs = append(pairs, fmt.Sprintf("k%d=v", i))
+	}
+	return strings.Join(pairs, "&")
+}
+
+// TestArgumentsLimitRaisesReqbodyError asserts that dropping arguments at
+// SecArgumentsLimit raises the body error flag and message in every collection
+// that caps, with the message ModSecurity reports. The dropped arguments are
+// the attacker-chosen tail, so the truncation has to be visible to the rules
+// and not only to the debug log. RESPONSE_ARGS is filled while the response is
+// processed, so it reports through RES_BODY_ERROR; every other collection
+// reports through REQBODY_ERROR.
+func TestArgumentsLimitRaisesReqbodyError(t *testing.T) {
+	// Spelled out once: this is the text ModSecurity emits, and a ruleset
+	// matching on it verbatim breaks if it drifts.
+	if want, have := "SecArgumentsLimit exceeded", argumentsLimitErrorMsg; want != have {
+		t.Fatalf("the message no longer matches ModSecurity, want %q, have %q", want, have)
+	}
+	for _, tc := range []struct {
+		name         string
+		responseSide bool
+		fill         func(tx *Transaction, keys int)
+	}{
+		{
+			name: "extract_get",
+			fill: func(tx *Transaction, keys int) {
+				tx.ExtractGetArguments(queryString(keys))
+			},
+		},
+		{
+			name: "process_uri",
+			fill: func(tx *Transaction, keys int) {
+				tx.ProcessURI("/?"+queryString(keys), "GET", "HTTP/1.1")
+			},
+		},
+		{
+			name: "add_get",
+			fill: func(tx *Transaction, keys int) {
+				for i := 0; i < keys; i++ {
+					tx.AddGetRequestArgument(fmt.Sprintf("k%d", i), "v")
+				}
+			},
+		},
+		{
+			name: "add_path",
+			fill: func(tx *Transaction, keys int) {
+				for i := 0; i < keys; i++ {
+					tx.AddPathRequestArgument(fmt.Sprintf("k%d", i), "v")
+				}
+			},
+		},
+		{
+			name: "add_post",
+			fill: func(tx *Transaction, keys int) {
+				for i := 0; i < keys; i++ {
+					tx.AddPostRequestArgument(fmt.Sprintf("k%d", i), "v")
+				}
+			},
+		},
+		{
+			name:         "add_response",
+			responseSide: true,
+			fill: func(tx *Transaction, keys int) {
+				for i := 0; i < keys; i++ {
+					tx.AddResponseArgument(fmt.Sprintf("k%d", i), "v")
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, c := range []struct {
+				keys    int
+				want    string
+				wantMsg string
+			}{
+				{keys: 3, want: "0", wantMsg: ""},
+				{keys: 4, want: "1", wantMsg: argumentsLimitErrorMsg},
+			} {
+				waf := NewWAF()
+				waf.ArgumentLimit = 3
+				tx := waf.NewTransaction()
+				tc.fill(tx, c.keys)
+
+				flagName, msgName := "REQBODY_ERROR", "REQBODY_ERROR_MSG"
+				flag, msg := tx.variables.reqbodyError, tx.variables.reqbodyErrorMsg
+				quiet, quietName := tx.variables.resBodyError, "RES_BODY_ERROR"
+				if tc.responseSide {
+					flagName, msgName = "RES_BODY_ERROR", "RES_BODY_ERROR_MSG"
+					flag, msg = tx.variables.resBodyError, tx.variables.resBodyErrorMsg
+					quiet, quietName = tx.variables.reqbodyError, "REQBODY_ERROR"
+				}
+				if have := flag.Get(); c.want != have {
+					t.Errorf("%d keys under a limit of 3: unexpected %s, want %q, have %q", c.keys, flagName, c.want, have)
+				}
+				if have := msg.Get(); c.wantMsg != have {
+					t.Errorf("%d keys under a limit of 3: unexpected %s, want %q, have %q", c.keys, msgName, c.wantMsg, have)
+				}
+				// The two sides report independently: a cap on one must not
+				// make a rule on the other match.
+				if want, have := "0", quiet.Get(); want != have {
+					t.Errorf("%d keys under a limit of 3: truncation must not touch %s, want %q, have %q", c.keys, quietName, want, have)
+				}
+				if err := tx.Close(); err != nil {
+					t.Fatalf("Failed to close transaction: %s", err.Error())
+				}
+			}
+		})
+	}
+}
+
+// TestBodylessRequestOverArgumentsLimitRaisesReqbodyError asserts that a
+// request carrying no body at all raises REQBODY_ERROR once its query string
+// alone passes SecArgumentsLimit. The query string caps the same way a body
+// does and reports through the same variables, as ModSecurity does, so a
+// ruleset written against REQBODY_ERROR sees query-string truncation too.
+func TestBodylessRequestOverArgumentsLimitRaisesReqbodyError(t *testing.T) {
+	waf := NewWAF()
+	waf.ArgumentLimit = 3
+	tx := waf.NewTransaction()
+	tx.ProcessURI("/?"+queryString(4), "GET", "HTTP/1.1")
+	tx.ProcessRequestHeaders()
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "1", tx.variables.reqbodyError.Get(); want != have {
+		t.Errorf("unexpected REQBODY_ERROR, want %q, have %q", want, have)
+	}
+	if want, have := argumentsLimitErrorMsg, tx.variables.reqbodyErrorMsg.Get(); want != have {
+		t.Errorf("unexpected REQBODY_ERROR_MSG, want %q, have %q", want, have)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+}
+
+// TestArgumentsLimitKeepsFirstBodyErrorMessage asserts that an argument limit
+// trip leaves a message a parse failure already set alone, so the more
+// specific diagnosis is the one an operator reads.
+func TestArgumentsLimitKeepsFirstBodyErrorMessage(t *testing.T) {
+	waf := NewWAF()
+	waf.RequestBodyAccess = true
+	waf.ArgumentLimit = 2
+	tx := waf.NewTransaction()
+	tx.AddRequestHeader("content-type", "application/xml")
+	tx.ProcessRequestHeaders()
+	tx.variables.reqbodyProcessor.Set("XML")
+	if _, err := tx.requestBodyBuffer.Write([]byte("<root><1a/></root>")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Fatal(err)
+	}
+	want := tx.variables.reqbodyErrorMsg.Get()
+	if want == "" || strings.Contains(want, argumentsLimitErrorMsg) {
+		t.Fatalf("the malformed body did not report a parse failure, REQBODY_ERROR_MSG is %q", want)
+	}
+
+	for i := 0; i <= waf.ArgumentLimit; i++ {
+		tx.AddPostRequestArgument(fmt.Sprintf("k%d", i), "v")
+	}
+	if have := tx.variables.reqbodyErrorMsg.Get(); want != have {
+		t.Errorf("the argument limit overwrote the parse failure message, want %q, have %q", want, have)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+}
+
+// TestBodyErrorMessageFollowsTheLatestParseFailure asserts that a parse failure
+// replaces a message an argument limit trip already set. The write-once guard
+// is deliberately one-directional, as in ModSecurity, where it lives inside
+// add_argument() alone: a truncation notice gives way to the parser's own
+// diagnosis, while the reverse order keeps the parse failure.
+func TestBodyErrorMessageFollowsTheLatestParseFailure(t *testing.T) {
+	waf := NewWAF()
+	waf.RequestBodyAccess = true
+	waf.ArgumentLimit = 2
+	tx := waf.NewTransaction()
+	tx.ProcessURI("/?a=1&b=2&c=3", "GET", "HTTP/1.1")
+	if want, have := argumentsLimitErrorMsg, tx.variables.reqbodyErrorMsg.Get(); want != have {
+		t.Fatalf("the query string did not trip the limit, REQBODY_ERROR_MSG is %q, want %q", have, want)
+	}
+
+	tx.AddRequestHeader("content-type", "application/xml")
+	tx.ProcessRequestHeaders()
+	tx.variables.reqbodyProcessor.Set("XML")
+	if _, err := tx.requestBodyBuffer.Write([]byte("<root><1a/></root>")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Fatal(err)
+	}
+	have := tx.variables.reqbodyErrorMsg.Get()
+	if have == "" || strings.Contains(have, argumentsLimitErrorMsg) {
+		t.Errorf("the parse failure did not replace the truncation notice, REQBODY_ERROR_MSG is %q", have)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+}
+
+// TestResponseBodyErrorVariablesAreAddressable asserts that the RES_BODY_ERROR
+// family resolves to the collection that holds it. An unmapped variable falls
+// back to the noop collection, so a rule written against it compiles and then
+// never matches whatever the response path raised.
+func TestResponseBodyErrorVariablesAreAddressable(t *testing.T) {
+	waf := NewWAF()
+	tx := waf.NewTransaction()
+	for _, tc := range []struct {
+		variable variables.RuleVariable
+		holder   *collections.Single
+	}{
+		{variables.ResBodyError, tx.variables.resBodyError},
+		{variables.ResBodyErrorMsg, tx.variables.resBodyErrorMsg},
+		{variables.ResBodyProcessorError, tx.variables.resBodyProcessorError},
+		{variables.ResBodyProcessorErrorMsg, tx.variables.resBodyProcessorErrorMsg},
+	} {
+		// The value is the variable's own name, so resolving to a sibling of
+		// the right shape is a mismatch rather than a coincidence.
+		want := tc.variable.Name()
+		tc.holder.Set(want)
+		var have []string
+		for _, md := range tx.Collection(tc.variable).FindAll() {
+			have = append(have, md.Value())
+		}
+		if len(have) != 1 || have[0] != want {
+			t.Errorf("a rule on %s cannot see what the response path raised, want [%q], have %q", tc.variable.Name(), want, have)
+		}
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+}
+
+// TestResponseBodyErrorVariablesSeeded asserts that a fresh transaction reads
+// "0" from the RES_BODY_ERROR flags, so a rule written as
+// `SecRule RES_BODY_ERROR "!@eq 0"` compares against a number on a clean
+// response instead of an empty string, as it does on the request side.
+func TestResponseBodyErrorVariablesSeeded(t *testing.T) {
+	waf := NewWAF()
+	tx := waf.NewTransaction()
+	for _, v := range []struct {
+		name string
+		have string
+	}{
+		{"RES_BODY_ERROR", tx.variables.resBodyError.Get()},
+		{"RES_BODY_PROCESSOR_ERROR", tx.variables.resBodyProcessorError.Get()},
+	} {
+		if want := "0"; want != v.have {
+			t.Errorf("unexpected %s on a clean response, want %q, have %q", v.name, want, v.have)
+		}
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+}
+
+// TestResponseBodyErrorVariablesMinPhase asserts that the RES_BODY_ERROR family
+// is known to be populated in the response body phase. A variable with no phase
+// makes a chained rule using it evaluate in every phase, where the flags still
+// hold their seeded "0".
+func TestResponseBodyErrorVariablesMinPhase(t *testing.T) {
+	for _, v := range []variables.RuleVariable{
+		variables.ResBodyError,
+		variables.ResBodyErrorMsg,
+		variables.ResBodyProcessorError,
+		variables.ResBodyProcessorErrorMsg,
+	} {
+		if want, have := types.PhaseResponseBody, minPhase(v); want != have {
+			t.Errorf("unexpected min phase for %s, want %d, have %d", v.Name(), want, have)
+		}
+	}
+}
+
 func TestAddPostArgsWithOverlimit(t *testing.T) {
 	testCases := []int{1, 2, 5, 1000}
 
@@ -2159,6 +2567,312 @@ func TestAddResponseArgsWithOverlimit(t *testing.T) {
 		if err := tx.Close(); err != nil {
 			t.Fatalf("Failed to close transaction: %s", err.Error())
 		}
+	}
+}
+
+func oversizedJSONBody(members int) string {
+	body := strings.Builder{}
+	body.WriteString("{")
+	for i := 0; i < members; i++ {
+		if i > 0 {
+			body.WriteString(",")
+		}
+		fmt.Fprintf(&body, `"k%d":"v"`, i)
+	}
+	body.WriteString("}")
+	return body.String()
+}
+
+// TestProcessRequestBodyArgumentsLimit asserts that a body holding more members
+// than SecArgumentsLimit raises REQBODY_ERROR and names SecArgumentsLimit in
+// REQBODY_ERROR_MSG, whichever processor parsed it, and leaves the
+// REQBODY_PROCESSOR_ERROR family untouched: the processor itself did not fail.
+// The collection keeps exactly SecArgumentsLimit members, so what fits under
+// the limit stays available to the rules.
+func TestProcessRequestBodyArgumentsLimit(t *testing.T) {
+	const members = 50
+
+	for _, tc := range []struct {
+		name        string
+		processor   string
+		contentType string
+		body        string
+		count       func(tx *Transaction) int
+	}{
+		{
+			name:        "json",
+			processor:   "JSON",
+			contentType: "application/json",
+			body:        oversizedJSONBody(members),
+			count:       func(tx *Transaction) int { return tx.variables.argsPost.Len() },
+		},
+		{
+			name:        "urlencoded",
+			processor:   "URLENCODED",
+			contentType: "application/x-www-form-urlencoded",
+			body: func() string {
+				pairs := make([]string, 0, members)
+				for i := 0; i < members; i++ {
+					pairs = append(pairs, fmt.Sprintf("k%d=v", i))
+				}
+				return strings.Join(pairs, "&")
+			}(),
+			count: func(tx *Transaction) int { return tx.variables.argsPost.Len() },
+		},
+		{
+			// REQUEST_XML is budgeted at MaxNodesPerArgument members per unit of
+			// SecArgumentsLimit, so the body carries that many attributes per
+			// member and the count is converted back into those units.
+			name:        "xml",
+			processor:   "XML",
+			contentType: "application/xml",
+			body: func() string {
+				var b strings.Builder
+				b.WriteString("<root>")
+				for i := 0; i < members*bodyprocessors.MaxNodesPerArgument; i++ {
+					fmt.Fprintf(&b, `<e a="v%d"/>`, i)
+				}
+				b.WriteString("</root>")
+				return b.String()
+			}(),
+			count: func(tx *Transaction) int {
+				return len(tx.variables.requestXML.FindAll()) / bodyprocessors.MaxNodesPerArgument
+			},
+		},
+		{
+			name:        "multipart",
+			processor:   "MULTIPART",
+			contentType: "multipart/form-data; boundary=X",
+			body: func() string {
+				var b strings.Builder
+				for i := 0; i < members; i++ {
+					fmt.Fprintf(&b, "--X\r\nContent-Disposition: form-data; name=\"k%d\"\r\n\r\nv\r\n", i)
+				}
+				b.WriteString("--X--\r\n")
+				return b.String()
+			}(),
+			count: func(tx *Transaction) int { return tx.variables.argsPost.Len() },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			waf := NewWAF()
+			waf.RequestBodyAccess = true
+			waf.ArgumentLimit = 10
+			tx := waf.NewTransaction()
+			tx.AddRequestHeader("content-type", tc.contentType)
+			tx.ProcessRequestHeaders()
+			tx.variables.reqbodyProcessor.Set(tc.processor)
+			if _, err := tx.requestBodyBuffer.Write([]byte(tc.body)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tx.ProcessRequestBody(); err != nil {
+				t.Fatal(err)
+			}
+			if want, have := "1", tx.variables.reqbodyError.Get(); want != have {
+				t.Errorf("unexpected REQBODY_ERROR, want %q, have %q", want, have)
+			}
+			if want, have := argumentsLimitErrorMsg, tx.variables.reqbodyErrorMsg.Get(); want != have {
+				t.Errorf("unexpected REQBODY_ERROR_MSG, want %q, have %q", want, have)
+			}
+			for _, v := range []struct {
+				name string
+				have string
+			}{
+				{"REQBODY_PROCESSOR_ERROR", tx.variables.reqbodyProcessorError.Get()},
+				{"REQBODY_PROCESSOR_ERROR_MSG", tx.variables.reqbodyProcessorErrorMsg.Get()},
+			} {
+				if v.have != "" && v.have != "0" {
+					t.Errorf("a count trip must not fail the body processor, %s is %q", v.name, v.have)
+				}
+			}
+			if want, have := waf.ArgumentLimit, tc.count(tx); want != have {
+				t.Errorf("truncation must fill the collection to the limit and stop, want %d members, have %d", want, have)
+			}
+			if err := tx.Close(); err != nil {
+				t.Fatalf("Failed to close transaction: %s", err.Error())
+			}
+		})
+	}
+}
+
+// TestProcessRequestBodyJSONDecodedSizeIsFatal asserts that the JSON
+// decoded-bytes budget stays fail-closed: a body that inflates far beyond its
+// own size raises REQBODY_ERROR and names the budget in REQBODY_ERROR_MSG
+// rather than pointing at SecArgumentsLimit, which does not govern it.
+func TestProcessRequestBodyJSONDecodedSizeIsFatal(t *testing.T) {
+	var body strings.Builder
+	pad := strings.Repeat("A", 1000)
+	const levels = 900
+	for i := 0; i < levels; i++ {
+		fmt.Fprintf(&body, `{"z":1,"%s":`, pad)
+	}
+	body.WriteString("1")
+	body.WriteString(strings.Repeat("}", levels))
+
+	waf := NewWAF()
+	waf.RequestBodyAccess = true
+	tx := waf.NewTransaction()
+	tx.AddRequestHeader("content-type", "application/json")
+	tx.ProcessRequestHeaders()
+	tx.variables.reqbodyProcessor.Set("JSON")
+	if _, err := tx.requestBodyBuffer.Write([]byte(body.String())); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "1", tx.variables.reqbodyError.Get(); want != have {
+		t.Errorf("unexpected REQBODY_ERROR, want %q, have %q", want, have)
+	}
+	if have := tx.variables.reqbodyErrorMsg.Get(); !strings.Contains(have, "json decoded size limit exceeded") {
+		t.Errorf("REQBODY_ERROR_MSG does not name the budget that tripped, have %q", have)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+}
+
+// TestProcessResponseBodyArgumentsLimit asserts that a response body holding
+// more members than SecArgumentsLimit raises RES_BODY_ERROR and names
+// SecArgumentsLimit in RES_BODY_ERROR_MSG, and leaves the
+// RES_BODY_PROCESSOR_ERROR family untouched: the processor itself did not
+// fail. The collection keeps exactly SecArgumentsLimit members, so what fits
+// under the limit stays available to the rules.
+func TestProcessResponseBodyArgumentsLimit(t *testing.T) {
+	const members = 50
+
+	for _, tc := range []struct {
+		name      string
+		processor string
+		body      string
+		count     func(tx *Transaction) int
+	}{
+		{
+			name:      "json",
+			processor: "JSON",
+			body:      oversizedJSONBody(members),
+			count:     func(tx *Transaction) int { return tx.variables.responseArgs.Len() },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			waf := NewWAF()
+			waf.ResponseBodyAccess = true
+			waf.ArgumentLimit = 10
+			tx := waf.NewTransaction()
+			tx.ForceResponseBodyVariable = true
+			tx.variables.ResponseBodyProcessor().(*collections.Single).Set(tc.processor)
+			tx.ProcessRequestHeaders()
+			if _, err := tx.ProcessRequestBody(); err != nil {
+				t.Fatal(err)
+			}
+			tx.ProcessResponseHeaders(200, "HTTP/1.1")
+			if _, _, err := tx.WriteResponseBody([]byte(tc.body)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tx.ProcessResponseBody(); err != nil {
+				t.Fatal(err)
+			}
+			if want, have := "1", tx.variables.resBodyError.Get(); want != have {
+				t.Errorf("unexpected RES_BODY_ERROR, want %q, have %q", want, have)
+			}
+			if want, have := argumentsLimitErrorMsg, tx.variables.resBodyErrorMsg.Get(); want != have {
+				t.Errorf("unexpected RES_BODY_ERROR_MSG, want %q, have %q", want, have)
+			}
+			for _, v := range []struct {
+				name string
+				have string
+			}{
+				{"RES_BODY_PROCESSOR_ERROR", tx.variables.resBodyProcessorError.Get()},
+				{"RES_BODY_PROCESSOR_ERROR_MSG", tx.variables.resBodyProcessorErrorMsg.Get()},
+			} {
+				if v.have != "" && v.have != "0" {
+					t.Errorf("a count trip must not fail the body processor, %s is %q", v.name, v.have)
+				}
+			}
+			if want, have := waf.ArgumentLimit, tc.count(tx); want != have {
+				t.Errorf("truncation must fill the collection to the limit and stop, want %d members, have %d", want, have)
+			}
+			if err := tx.Close(); err != nil {
+				t.Fatalf("Failed to close transaction: %s", err.Error())
+			}
+		})
+	}
+}
+
+// TestProcessResponseBodyJSONDecodedSizeIsFatal asserts that the JSON
+// decoded-bytes budget stays fail-closed on the response path: a body that
+// inflates far beyond its own size raises RES_BODY_ERROR and names the budget
+// in RES_BODY_ERROR_MSG, unlike a plain SecArgumentsLimit count trip.
+func TestProcessResponseBodyJSONDecodedSizeIsFatal(t *testing.T) {
+	var body strings.Builder
+	pad := strings.Repeat("A", 300)
+	const levels = 900
+	for i := 0; i < levels; i++ {
+		fmt.Fprintf(&body, `{"z":1,"%s":`, pad)
+	}
+	body.WriteString("1")
+	body.WriteString(strings.Repeat("}", levels))
+
+	waf := NewWAF()
+	waf.ResponseBodyAccess = true
+	waf.ResponseBodyLimit = int64(body.Len())
+	tx := waf.NewTransaction()
+	tx.ForceResponseBodyVariable = true
+	tx.variables.ResponseBodyProcessor().(*collections.Single).Set("JSON")
+	tx.ProcessRequestHeaders()
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Fatal(err)
+	}
+	tx.ProcessResponseHeaders(200, "HTTP/1.1")
+	if _, _, err := tx.WriteResponseBody([]byte(body.String())); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ProcessResponseBody(); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "1", tx.variables.resBodyError.Get(); want != have {
+		t.Errorf("unexpected RES_BODY_ERROR, want %q, have %q", want, have)
+	}
+	if have := tx.variables.resBodyErrorMsg.Get(); !strings.Contains(have, "json decoded size limit exceeded") {
+		t.Errorf("RES_BODY_ERROR_MSG does not name the budget that tripped, have %q", have)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+}
+
+// TestProcessResponseBodyJSONDepthLimit asserts that SecRequestBodyJsonDepthLimit
+// reaches the response body processor: a response nested past the configured
+// depth raises RES_BODY_ERROR and names the recursion failure, rather than
+// parsing to an unbounded depth.
+func TestProcessResponseBodyJSONDepthLimit(t *testing.T) {
+	body := strings.Repeat("[", 200) + strings.Repeat("]", 200)
+
+	waf := NewWAF()
+	waf.ResponseBodyAccess = true
+	waf.RequestBodyJsonDepthLimit = 100
+	tx := waf.NewTransaction()
+	tx.ForceResponseBodyVariable = true
+	tx.variables.ResponseBodyProcessor().(*collections.Single).Set("JSON")
+	tx.ProcessRequestHeaders()
+	if _, err := tx.ProcessRequestBody(); err != nil {
+		t.Fatal(err)
+	}
+	tx.ProcessResponseHeaders(200, "HTTP/1.1")
+	if _, _, err := tx.WriteResponseBody([]byte(body)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ProcessResponseBody(); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := "1", tx.variables.resBodyError.Get(); want != have {
+		t.Errorf("unexpected RES_BODY_ERROR, want %q, have %q", want, have)
+	}
+	if have := tx.variables.resBodyErrorMsg.Get(); !strings.Contains(have, "max recursion reached") {
+		t.Errorf("RES_BODY_ERROR_MSG does not name the recursion failure, have %q", have)
+	}
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
 	}
 }
 
@@ -2662,4 +3376,105 @@ func BenchmarkRuleEvalWithRemovedRules(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		waf.Rules.Eval(types.PhaseRequestHeaders, tx)
 	}
+}
+
+// TestBodyLimitsDoNotLogAtErrorLevel asserts that no limit a client can trip
+// with a syntactically valid body produces an error-level log line. Error is
+// reserved for bodies the parser could not read, so a client cannot flood the
+// log by sending large well-formed input.
+func TestBodyLimitsDoNotLogAtErrorLevel(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tune func(*WAF)
+		body string
+	}{
+		{
+			name: "arguments_limit",
+			tune: func(w *WAF) { w.ArgumentLimit = 10 },
+			body: `{"a":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20]}`,
+		},
+		{
+			name: "json_recursion_limit",
+			tune: func(w *WAF) { w.RequestBodyJsonDepthLimit = 20 },
+			body: strings.Repeat(`{"a":`, 40) + "1" + strings.Repeat("}", 40),
+		},
+		{
+			name: "json_decoded_size_limit",
+			tune: func(w *WAF) { w.ArgumentLimit = 1000000 },
+			body: deepWideJSONBody(200, 400),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var debugLog strings.Builder
+			waf := NewWAF()
+			waf.RequestBodyAccess = true
+			tc.tune(waf)
+			tx := waf.NewTransaction()
+			tx.debugLogger = debuglog.Default().WithLevel(debuglog.LevelDebug).WithOutput(&debugLog)
+			tx.AddRequestHeader("content-type", "application/json")
+			tx.ProcessRequestHeaders()
+			tx.variables.reqbodyProcessor.Set("JSON")
+			if _, err := tx.requestBodyBuffer.Write([]byte(tc.body)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tx.ProcessRequestBody(); err != nil {
+				t.Fatal(err)
+			}
+			// Each body must actually trip its limit, or the assertion below is
+			// vacuous.
+			if want, have := "1", tx.variables.reqbodyError.Get(); want != have {
+				t.Fatalf("the body did not trip the limit, REQBODY_ERROR is %q", have)
+			}
+			if strings.Contains(debugLog.String(), "[ERROR]") {
+				t.Errorf("a client-triggerable limit logged at error level:\n%s", debugLog.String())
+			}
+		})
+
+		t.Run(tc.name+"_response", func(t *testing.T) {
+			var debugLog strings.Builder
+			waf := NewWAF()
+			waf.ResponseBodyAccess = true
+			tc.tune(waf)
+			tx := waf.NewTransaction()
+			tx.debugLogger = debuglog.Default().WithLevel(debuglog.LevelDebug).WithOutput(&debugLog)
+			tx.ForceResponseBodyVariable = true
+			tx.variables.ResponseBodyProcessor().(*collections.Single).Set("JSON")
+			tx.ProcessRequestHeaders()
+			if _, err := tx.ProcessRequestBody(); err != nil {
+				t.Fatal(err)
+			}
+			tx.ProcessResponseHeaders(200, "HTTP/1.1")
+			if _, _, err := tx.WriteResponseBody([]byte(tc.body)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tx.ProcessResponseBody(); err != nil {
+				t.Fatal(err)
+			}
+			if want, have := "1", tx.variables.resBodyError.Get(); want != have {
+				t.Fatalf("the body did not trip the limit, RES_BODY_ERROR is %q", have)
+			}
+			if strings.Contains(debugLog.String(), "[ERROR]") {
+				t.Errorf("a client-triggerable limit logged at error level:\n%s", debugLog.String())
+			}
+		})
+	}
+}
+
+// deepWideJSONBody builds a body that nests to levels and then fans out into
+// leaves, so every flattened path shares one long prefix.
+func deepWideJSONBody(levels, leaves int) string {
+	b := strings.Builder{}
+	for i := 0; i < levels; i++ {
+		fmt.Fprintf(&b, `{"nesting_level_%d":`, i)
+	}
+	b.WriteString("{")
+	for i := 0; i < leaves; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `"leaf_%d":"%s"`, i, strings.Repeat("v", 200))
+	}
+	b.WriteString("}")
+	b.WriteString(strings.Repeat("}", levels))
+	return b.String()
 }

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -3070,6 +3070,130 @@ func TestUploadKeepFiles(t *testing.T) {
 	})
 }
 
+func TestCloseReleasesPerRequestReferences(t *testing.T) {
+	waf := NewWAF()
+	tx := waf.NewTransaction()
+
+	rule := NewRule()
+	rule.ID_ = 1234
+	rule.Log = true
+	for i := 0; i < 10; i++ {
+		tx.MatchRule(rule, []types.MatchData{
+			&corazarules.MatchData{
+				Variable_: variables.ArgsPost,
+				Key_:      "key",
+				Value_:    "value",
+			},
+		})
+	}
+	tx.detectionOnlyInterruption = &types.Interruption{Status: 403}
+	tx.transformationCache[transformationKey{argIndex: 1}] = transformationValue{arg: "value"}
+	tx.SetRuleFilter(&RuleFilterWrapper{})
+
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+
+	mrs := tx.matchedRules
+	// Reslicing to zero length would keep every matched rule reachable through
+	// the backing array, so the slice itself must be released.
+	if mrs != nil {
+		t.Errorf("expected matched rules to be released after Close, got %d entries with capacity %d", len(mrs), cap(mrs))
+	}
+	if tx.ruleFilter != nil {
+		t.Error("expected ruleFilter to be nil after Close")
+	}
+	if tx.detectionOnlyInterruption != nil {
+		t.Error("expected detectionOnlyInterruption to be nil after Close")
+	}
+	if tx.context != nil {
+		t.Error("expected context to be nil after Close")
+	}
+	if len(tx.transformationCache) != 0 {
+		t.Errorf("expected empty transformation cache after Close, got %d entries", len(tx.transformationCache))
+	}
+}
+
+func TestCloseKeepsRelevantFilesBeforeReleasingMatchedRules(t *testing.T) {
+	if !environment.HasAccessToFS {
+		t.Skip("skipping test as it requires access to filesystem")
+	}
+
+	waf := NewWAF()
+	waf.UploadKeepFiles = types.UploadKeepFilesRelevantOnly
+	tx := waf.NewTransaction()
+
+	f, err := os.CreateTemp(t.TempDir(), "crztest*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile := f.Name()
+	if err := f.Close(); err != nil {
+		t.Fatalf("failed to close temp file: %v", err)
+	}
+	tx.Variables().FilesTmpNames().(*collections.Map).Add("", tmpFile)
+
+	tx.matchedRules = append(tx.matchedRules, &corazarules.MatchedRule{Log_: true})
+
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+
+	if _, err := os.Stat(tmpFile); err != nil {
+		t.Fatal("expected temp file to be kept when a log-relevant rule matched")
+	}
+	if tx.matchedRules != nil {
+		t.Error("expected matched rules to be released after Close")
+	}
+}
+
+func TestTransactionReuseAfterClose(t *testing.T) {
+	waf := NewWAF()
+	tx := waf.NewTransaction()
+
+	rule := NewRule()
+	rule.ID_ = 1234
+	rule.Log = true
+	tx.MatchRule(rule, []types.MatchData{
+		&corazarules.MatchData{Variable_: variables.UniqueID},
+	})
+	tx.detectionOnlyInterruption = &types.Interruption{Status: 403}
+	tx.ForceRequestBodyVariable = true
+	tx.ForceResponseBodyVariable = true
+
+	if err := tx.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+
+	tx2 := waf.NewTransaction()
+	if len(tx2.matchedRules) != 0 {
+		t.Errorf("expected no matched rules on a fresh transaction, got %d", len(tx2.matchedRules))
+	}
+	if tx2.detectionOnlyInterruption != nil {
+		t.Error("expected no detection-only interruption on a fresh transaction")
+	}
+	// A stale force flag makes the next request buffer and parse a body its own
+	// configuration excludes.
+	if tx2.ForceRequestBodyVariable {
+		t.Error("expected ForceRequestBodyVariable to be unset on a fresh transaction")
+	}
+	if tx2.ForceResponseBodyVariable {
+		t.Error("expected ForceResponseBodyVariable to be unset on a fresh transaction")
+	}
+	if tx2.context == nil {
+		t.Error("expected a fresh transaction to have a context")
+	}
+
+	tx2.ProcessConnection("127.0.0.1", 8080, "127.0.0.1", 80)
+	tx2.ProcessURI("/test", "GET", "HTTP/1.1")
+	if it := tx2.ProcessRequestHeaders(); it != nil {
+		t.Errorf("unexpected interruption on a fresh transaction: %+v", it)
+	}
+	if err := tx2.Close(); err != nil {
+		t.Fatalf("Failed to close transaction: %s", err.Error())
+	}
+}
+
 func TestRequestFilename(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/corazawaf/variable_selectability_test.go
+++ b/internal/corazawaf/variable_selectability_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/corazawaf/coraza/v3/collection"
+	"github.com/corazawaf/coraza/v3/internal/collections"
 	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
@@ -55,5 +56,63 @@ func TestCanBeSelectedMatchesKeyedCollection(t *testing.T) {
 	// where the enum ends.
 	if want := int(variables.ScriptUsername); checked != want {
 		t.Errorf("walked %d variables, expected the whole enum through SCRIPT_USERNAME (%d)", checked, want)
+	}
+}
+
+// TestRuleVisibleCollectionsAreReset pins the invariant behind
+// TransactionVariables.All: every collection a rule can reach through
+// Collection() has to be enumerated there, because reset() walks All() and
+// transactions are recycled through a pool.
+//
+// A collection reachable by a rule but missing from All() keeps its value for
+// whichever request gets that transaction next. For an error flag that means a
+// clean request inherits the previous one's failure and is denied by a rule it
+// never tripped, which is why this is worth a structural test rather than a
+// per-variable one: the mistake is invisible at the call site and shows up
+// only under pool reuse.
+//
+// The persistent collections are the deliberate exception - reset() clears
+// them explicitly, and the comment there explains why they stay out of All().
+func TestRuleVisibleCollectionsAreReset(t *testing.T) {
+	waf := NewWAF()
+	tx := waf.NewTransaction()
+	t.Cleanup(func() {
+		if err := tx.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	enumerated := make(map[collection.Collection]struct{})
+	tx.variables.All(func(_ variables.RuleVariable, col collection.Collection) bool {
+		enumerated[col] = struct{}{}
+		return true
+	})
+
+	persistent := map[variables.RuleVariable]struct{}{
+		variables.Global:   {},
+		variables.Resource: {},
+		variables.IP:       {},
+		variables.Session:  {},
+		variables.User:     {},
+	}
+
+	// RuleVariable is a byte; the bound keeps a broken sentinel from looping forever.
+	for i := 1; i < 256; i++ {
+		v := variables.RuleVariable(i)
+		if v.Name() == "INVALID_VARIABLE" {
+			break
+		}
+		if _, skip := persistent[v]; skip {
+			continue
+		}
+		col := tx.Collection(v)
+		// Noop is the fallback for variables no collection backs; nil is JSON,
+		// which Collection() leaves unimplemented.
+		if col == nil || col == collections.Noop {
+			continue
+		}
+		if _, ok := enumerated[col]; !ok {
+			t.Errorf("%s is reachable through Collection() but absent from All(), so it survives Close() and leaks into the next transaction", v.Name())
+		}
 	}
 }

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -209,12 +209,14 @@ func (w *WAF) newTransaction(opts Options) *Transaction {
 	tx.context = opts.Context
 	tx.matchedRules = []types.MatchedRule{}
 	tx.interruption = nil
+	tx.detectionOnlyInterruption = nil
 	tx.Logdata = "" // Deprecated, this variable is not used. Logdata for each matched rule is stored in the MatchData field.
 	tx.SkipAfter = ""
 	tx.AuditEngine = w.AuditEngine
 	tx.AuditLogParts = w.AuditLogParts
 	tx.AuditLogFormat = w.AuditLogFormat
 	tx.ForceRequestBodyVariable = false
+	tx.ForceResponseBodyVariable = false
 	tx.RequestBodyAccess = w.RequestBodyAccess
 	tx.RequestBodyLimit = w.RequestBodyLimit
 	tx.ResponseBodyAccess = w.ResponseBodyAccess

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -276,6 +276,8 @@ func (w *WAF) newTransaction(opts Options) *Transaction {
 	tx.variables.outboundDataError.Set("0")
 	tx.variables.reqbodyError.Set("0")
 	tx.variables.reqbodyProcessorError.Set("0")
+	tx.variables.resBodyError.Set("0")
+	tx.variables.resBodyProcessorError.Set("0")
 	tx.variables.requestBodyLength.Set("0")
 	tx.variables.duration.Set("0")
 	tx.variables.highestSeverity.Set(strconv.Itoa(defaultHighestSeverity))

--- a/internal/operators/rbl.go
+++ b/internal/operators/rbl.go
@@ -7,6 +7,7 @@ package operators
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -54,52 +55,58 @@ func newRBL(options plugintypes.OperatorOptions) (plugintypes.Operator, error) {
 // https://github.com/mrichman/godnsbl
 // https://github.com/SpiderLabs/ModSecurity/blob/b66224853b4e9d30e0a44d16b29d5ed3842a6b11/src/operators/rbl.cc
 func (o *rbl) Evaluate(tx plugintypes.TransactionState, ipAddr string) bool {
-	// TODO validate address
-	resC := make(chan bool)
-	ctx, cancel := context.WithCancel(context.Background())
+	if net.ParseIP(ipAddr) == nil {
+		// The operand is unvalidated request data, so it stays out of the message.
+		tx.DebugLogger().Warn().Msg("RBL lookup skipped: operand is not an IP address")
+		return false
+	}
 
-	defer func() {
-		cancel()
-	}()
+	// The lookups take the deadline through the context, so they unwind on
+	// their own and no work outlives Evaluate.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
 	addr := fmt.Sprintf("%s.%s", ipAddr, o.service)
-	var captures []string
-	go func(ctx context.Context) {
-		defer func() {
-			close(resC)
-		}()
-		res, err := o.resolver.LookupHost(ctx, addr)
-
-		if err != nil {
-			resC <- false
-			return
-		}
-		// var status string
-		if len(res) > 0 {
-			txt, err := o.resolver.LookupTXT(ctx, addr)
-			if err != nil {
-				resC <- false
-				return
-			}
-
-			if len(txt) > 0 {
-				status := txt[0]
-				captures = append(captures, status)
-				tx.Variables().TX().Set("httpbl_msg", []string{status})
-			}
-		}
-
-		resC <- true
-	}(ctx)
-
-	select {
-	case res := <-resC:
-		if res && len(captures) > 0 {
-			tx.CaptureField(0, captures[0])
-		}
-		return res
-	case <-time.After(timeout):
+	res, err := o.resolver.LookupHost(ctx, addr)
+	if err != nil {
+		logRBLLookupError(tx, addr, err)
 		return false
+	}
+
+	var status string
+	if len(res) > 0 {
+		txt, err := o.resolver.LookupTXT(ctx, addr)
+		if err != nil {
+			logRBLLookupError(tx, addr, err)
+			return false
+		}
+		if len(txt) > 0 {
+			status = txt[0]
+		}
+	}
+	if status != "" {
+		tx.Variables().TX().Set("httpbl_msg", []string{status})
+		tx.CaptureField(0, status)
+	}
+	return true
+}
+
+// logRBLLookupError reports a failed lookup at the level its cause deserves. A
+// missing record is the ordinary negative answer, a timeout is the service
+// being slow, and a cancelled lookup is the caller giving up, so none of them
+// is logged as an engine error: an unreachable or slow RBL would otherwise
+// write one error line per request.
+func logRBLLookupError(tx plugintypes.TransactionState, addr string, err error) {
+	var dnsErr *net.DNSError
+	switch {
+	case errors.As(err, &dnsErr) && dnsErr.IsNotFound:
+		tx.DebugLogger().Debug().Str("address", addr).Msg("RBL record not found")
+	case errors.Is(err, context.DeadlineExceeded), errors.As(err, &dnsErr) && dnsErr.IsTimeout:
+		tx.DebugLogger().Warn().Str("address", addr).Msg("RBL lookup timed out, treating IP as not listed")
+	case errors.Is(err, context.Canceled):
+		tx.DebugLogger().Debug().Str("address", addr).Msg("RBL lookup cancelled")
+	default:
+		tx.DebugLogger().Error().Err(err).Str("address", addr).Msg("RBL DNS lookup failed")
 	}
 }
 

--- a/internal/operators/rbl_test.go
+++ b/internal/operators/rbl_test.go
@@ -1,15 +1,23 @@
 // Copyright 2022 Juan Pablo Tosso and the OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !tinygo
+//go:build !tinygo && !coraza.disabled_operators.rbl
 
 package operators
 
 import (
+	"context"
+	"io"
+	"net"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/foxcpp/go-mockdns"
 
+	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
 	"github.com/corazawaf/coraza/v3/internal/corazawaf"
 )
@@ -33,14 +41,14 @@ func TestRbl(t *testing.T) {
 	logger := &testLogger{t}
 
 	srv, err := mockdns.NewServerWithLogger(map[string]mockdns.Zone{
-		"valid_no_txt.xbl.spamhaus.org.": {
+		"1.1.1.1.xbl.spamhaus.org.": {
 			A: []string{"1.2.3.4"},
 		},
-		"valid_txt.xbl.spamhaus.org.": {
+		"1.1.1.2.xbl.spamhaus.org.": {
 			A:   []string{"1.2.3.5"},
 			TXT: []string{"not blocked"},
 		},
-		"blocked.xbl.spamhaus.org.": {
+		"1.1.1.3.xbl.spamhaus.org.": {
 			A:   []string{"1.2.3.6"},
 			TXT: []string{"blocked"},
 		},
@@ -53,36 +61,232 @@ func TestRbl(t *testing.T) {
 	srv.PatchNet(op.(*rbl).resolver)
 	defer mockdns.UnpatchNet(op.(*rbl).resolver)
 
-	t.Run("Valid hostname with no TXT record", func(t *testing.T) {
-		if op.Evaluate(nil, "valid_no_txt") {
-			t.Errorf("Unexpected result for valid hostname with no TXT record")
+	t.Run("IP with an A record but no TXT record is not reported listed", func(t *testing.T) {
+		tx := corazawaf.NewWAF().NewTransaction()
+		if op.Evaluate(tx, "1.1.1.1") {
+			t.Errorf("an A record without a TXT record must not report the IP as listed")
 		}
 	})
 
-	t.Run("Valid hostname with TXT record", func(t *testing.T) {
+	t.Run("Listed IP with TXT record", func(t *testing.T) {
 		tx := corazawaf.NewWAF().NewTransaction()
-		if !op.Evaluate(tx, "valid_txt") {
-			t.Errorf("Unexpected result for valid hostname")
+		if !op.Evaluate(tx, "1.1.1.2") {
+			t.Errorf("Unexpected result for listed IP")
 		}
 		if want, have := "not blocked", tx.Variables().TX().Get("httpbl_msg")[0]; want != have {
-			t.Errorf("Unexpected result for valid hostname: want %q, have %q", want, have)
+			t.Errorf("Unexpected result for listed IP: want %q, have %q", want, have)
 		}
 	})
 
-	t.Run("Invalid hostname", func(t *testing.T) {
-		if op.Evaluate(nil, "invalid") {
-			t.Errorf("Unexpected result for invalid hostname")
-		}
-	})
-
-	t.Run("Blocked hostname", func(t *testing.T) {
+	t.Run("Unlisted IP", func(t *testing.T) {
 		tx := corazawaf.NewWAF().NewTransaction()
-		if !op.Evaluate(tx, "blocked") {
-			t.Fatal("Unexpected result for blocked hostname")
+		if op.Evaluate(tx, "127.0.0.2") {
+			t.Errorf("Unexpected result for unlisted IP")
 		}
-		t.Log(tx.Variables().TX().Get("httpbl_msg"))
-		if want, have := "blocked", tx.Variables().TX().Get("httpbl_msg")[0]; want != have {
-			t.Errorf("Unexpected result for valid hostname: want %q, have %q", want, have)
+		if got := tx.Variables().TX().Get("httpbl_msg"); len(got) > 0 {
+			t.Errorf("httpbl_msg set for unlisted IP: %q", got)
 		}
 	})
+
+	t.Run("Blocked IP", func(t *testing.T) {
+		tx := corazawaf.NewWAF().NewTransaction()
+		if !op.Evaluate(tx, "1.1.1.3") {
+			t.Fatal("Unexpected result for blocked IP")
+		}
+		if want, have := "blocked", tx.Variables().TX().Get("httpbl_msg")[0]; want != have {
+			t.Errorf("Unexpected result for blocked IP: want %q, have %q", want, have)
+		}
+	})
+}
+
+// errorCapturingWAF returns a WAF whose debug logger records, at Error level
+// only, every message that reaches the printer.
+func errorCapturingWAF() (*corazawaf.WAF, func() []string) {
+	var mu sync.Mutex
+	var lines []string
+	factory := func(io.Writer) debuglog.Printer {
+		return func(_ debuglog.Level, message, fields string) {
+			mu.Lock()
+			defer mu.Unlock()
+			lines = append(lines, message+" "+fields)
+		}
+	}
+	waf := corazawaf.NewWAF()
+	waf.Logger = debuglog.DefaultWithPrinterFactory(factory).WithLevel(debuglog.LevelError)
+	return waf, func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), lines...)
+	}
+}
+
+func TestRblUnlistedIPDoesNotLogError(t *testing.T) {
+	opts := plugintypes.OperatorOptions{
+		Arguments: "xbl.spamhaus.org",
+	}
+	op, err := newRBL(opts)
+	if err != nil {
+		t.Fatal("Cannot init rbl operator")
+	}
+
+	srv, err := mockdns.NewServerWithLogger(map[string]mockdns.Zone{}, &testLogger{t}, false)
+	if err != nil {
+		t.Fatalf("Cannot start mockdns server: %v", err)
+	}
+	defer srv.Close()
+	srv.PatchNet(op.(*rbl).resolver)
+	defer mockdns.UnpatchNet(op.(*rbl).resolver)
+
+	waf, capturedErrors := errorCapturingWAF()
+	tx := waf.NewTransaction()
+	if op.Evaluate(tx, "127.0.0.2") {
+		t.Error("Unexpected result for unlisted IP")
+	}
+	if lines := capturedErrors(); len(lines) > 0 {
+		t.Errorf("unlisted IP produced error-level log lines: %q", lines)
+	}
+}
+
+func TestRblInvalidIPSkipsLookup(t *testing.T) {
+	var dialed atomic.Bool
+	op := &rbl{
+		service: "xbl.spamhaus.org",
+		resolver: &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				dialed.Store(true)
+				return nil, context.Canceled
+			},
+		},
+	}
+	tx := corazawaf.NewWAF().NewTransaction()
+	if op.Evaluate(tx, "not-an-ip") {
+		t.Error("Unexpected result for non-IP input")
+	}
+	if dialed.Load() {
+		t.Error("Resolver was invoked for non-IP input")
+	}
+}
+
+// hangingResolver blocks every dial until the lookup context is cancelled,
+// so each Evaluate call runs into its timeout.
+func hangingResolver() *net.Resolver {
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+}
+
+func TestRblTimeout(t *testing.T) {
+	op := &rbl{service: "xbl.spamhaus.org", resolver: hangingResolver()}
+	tx := corazawaf.NewWAF().NewTransaction()
+
+	start := time.Now()
+	if op.Evaluate(tx, "127.0.0.2") {
+		t.Error("Unexpected result for timed out lookup")
+	}
+	if elapsed := time.Since(start); elapsed < timeout {
+		t.Errorf("Evaluate returned before the timeout: %v", elapsed)
+	}
+}
+
+// stableGoroutineCount waits out goroutines still winding down from earlier
+// tests and returns a goroutine count that held steady across several samples.
+func stableGoroutineCount(t *testing.T) int {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	last := runtime.NumGoroutine()
+	for stable := 0; stable < 5 && time.Now().Before(deadline); {
+		time.Sleep(10 * time.Millisecond)
+		if n := runtime.NumGoroutine(); n == last {
+			stable++
+		} else {
+			stable = 0
+			last = n
+		}
+	}
+	return last
+}
+
+// waitForGoroutineBaseline polls until the goroutine count drops to at most
+// baseline+slack, failing the test if it does not settle before the deadline.
+func waitForGoroutineBaseline(t *testing.T, baseline, slack int, deadline time.Duration) {
+	t.Helper()
+	limit := time.Now().Add(deadline)
+	for {
+		if runtime.NumGoroutine() <= baseline+slack {
+			return
+		}
+		if time.Now().After(limit) {
+			t.Fatalf("goroutine count did not settle: baseline=%d, now=%d", baseline, runtime.NumGoroutine())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestRblTimeoutDoesNotLeakGoroutines(t *testing.T) {
+	op := &rbl{service: "xbl.spamhaus.org", resolver: hangingResolver()}
+
+	before := stableGoroutineCount(t)
+
+	const evaluations = 5
+	var wg sync.WaitGroup
+	for i := 0; i < evaluations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tx := corazawaf.NewWAF().NewTransaction()
+			if op.Evaluate(tx, "127.0.0.2") {
+				t.Error("Unexpected result for timed out lookup")
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Goroutine teardown is asynchronous: poll until the count settles.
+	// A leak pins one goroutine per evaluation, so the tolerance must stay
+	// strictly below evaluations to keep the assertion falsifiable.
+	waitForGoroutineBaseline(t, before, evaluations-1, 3*time.Second)
+}
+
+func TestRblCancelledLookupDoesNotLogError(t *testing.T) {
+	op := &rbl{
+		service: "xbl.spamhaus.org",
+		resolver: &net.Resolver{
+			PreferGo: true,
+			Dial: func(context.Context, string, string) (net.Conn, error) {
+				return nil, context.Canceled
+			},
+		},
+	}
+
+	waf, capturedErrors := errorCapturingWAF()
+	tx := waf.NewTransaction()
+	if op.Evaluate(tx, "127.0.0.2") {
+		t.Error("Unexpected result for a cancelled lookup")
+	}
+	if lines := capturedErrors(); len(lines) > 0 {
+		t.Errorf("a cancelled lookup logged at error level: %v", lines)
+	}
+}
+
+func TestRblTimeoutLeavesTransactionUntouched(t *testing.T) {
+	op := &rbl{service: "xbl.spamhaus.org", resolver: hangingResolver()}
+
+	waf, capturedErrors := errorCapturingWAF()
+	tx := waf.NewTransaction()
+	if op.Evaluate(tx, "127.0.0.2") {
+		t.Error("Unexpected result for a lookup slower than the timeout")
+	}
+	if got := tx.Variables().TX().Get("httpbl_msg"); len(got) > 0 {
+		t.Errorf("a timed out lookup set httpbl_msg: %q", got)
+	}
+	// A slow or unreachable RBL is the service being slow, not an engine
+	// failure, so it must not write an error line per request.
+	if lines := capturedErrors(); len(lines) > 0 {
+		t.Errorf("a timed out lookup logged at error level: %v", lines)
+	}
 }

--- a/internal/seclang/directives.go
+++ b/internal/seclang/directives.go
@@ -286,7 +286,9 @@ func directiveSecRequestBodyAccess(options *DirectiveOptions) error {
 // Default: 1024
 // Syntax: SecRequestBodyJsonDepthLimit [LIMIT]
 // ---
-// Anything over the limit will generate a REQBODY_ERROR in the JSON body processor.
+// Anything over the limit will generate a REQBODY_ERROR (RES_BODY_ERROR on the
+// response path) in the JSON body processor; it bounds both request and
+// response body nesting.
 func directiveSecRequestBodyJsonDepthLimit(options *DirectiveOptions) error {
 	if len(options.Opts) == 0 {
 		return errEmptyOptions
@@ -1376,8 +1378,69 @@ func directiveSecDataset(options *DirectiveOptions) error {
 // Default: 1000
 // Syntax: SecArgumentsLimit [LIMIT]
 // ---
-// Exceeding the limit will not be included.
-// With JSON body processing, there is nothing to do when exceed the limit.
+// The collections a connector fills each cap on their own count: ARGS_GET,
+// ARGS_PATH, ARGS_POST and RESPONSE_ARGS stop accepting arguments once the
+// collection holds this many values. A repeated name costs one per value, the
+// way ModSecurity counts one argument table entry per key=value pair.
+//
+// Collections a body processor fills are capped by that processor instead.
+// Each fills in document order and stops the parse once its argument budget is
+// spent, so no work is done for arguments that are thrown away. ModSecurity v2
+// stops its JSON and XML parsers at the limit the same way, but keeps decoding
+// urlencoded and multipart bodies and discards what it will not store. What a
+// member costs, and how the budget relates to this limit, differ per processor:
+//   - urlencoded: ARGS_POST values, one member each, capped at this limit.
+//   - json: ARGS_POST (request) / RESPONSE_ARGS (response) flattened leaves,
+//     one member each, capped at this limit. The array-length entry recorded
+//     for a non-empty array is not an argument ModSecurity counts, so it is
+//     stored without drawing on the argument budget; those entries share a
+//     budget of this limit scaled by MaxEntriesPerArgument
+//     (internal/bodyprocessors/json.go), and exhausting it drops further
+//     lengths without reporting a truncation, because a document may hold more
+//     arrays than arguments and none of the dropped entries carries a value the
+//     document sent.
+//   - xml: REQUEST_XML attribute values and element text nodes share a budget
+//     of this limit scaled by MaxNodesPerArgument, which documents the scale
+//     (internal/bodyprocessors/xml.go).
+//   - multipart: one member per part, whether it is a field carrying an
+//     ARGS_POST value or a file carrying FILES, FILES_NAMES, FILES_SIZES and
+//     FILES_TMP_NAMES entries, capped at this limit. Fields are capped as
+//     ModSecurity v2 caps them, unlike v3 which leaves them uncapped.
+//     MULTIPART_PART_HEADERS draws on a separate budget of this limit scaled
+//     by MaxHeadersPerPart (internal/bodyprocessors/multipart.go); exhausting
+//     it truncates that collection without aborting the parse.
+//
+// A limit tuned against form posts may therefore trip earlier on JSON bodies,
+// which spend one member per flattened leaf.
+//
+// Whichever collection truncates, REQBODY_ERROR is set to 1 and
+// REQBODY_ERROR_MSG to "SecArgumentsLimit exceeded", the message ModSecurity
+// sets for a query-string, urlencoded or multipart trip; its JSON and XML
+// parsers name their own limits instead, where one string here keeps a rule
+// matching on the message portable across every body type. Rule 200002 in
+// coraza.conf-recommended denies on REQBODY_ERROR. A truncation notice
+// never overwrites a message already set, while a parse failure always
+// replaces one, so the parser's own diagnosis is the text an operator reads.
+// The query string and the path cap the same way and raise the same signal, so
+// a request carrying no body at all can set REQBODY_ERROR.
+// RESPONSE_ARGS is filled while the response is processed, so it and the
+// response body processors report through RES_BODY_ERROR and
+// RES_BODY_ERROR_MSG instead.
+//
+// The JSON body processor additionally bounds the total decoded bytes by the
+// body length plus a slack that is itself proportional to the body until it
+// reaches a ceiling (jsonDecodedBytesScale and jsonDecodedBytesSlack in
+// internal/bodyprocessors/json.go, which explain the shapes they guard
+// against). That budget bounds what is stored, not what inspecting it costs: a
+// body nested deeply enough spends the budget on long flattened paths, and
+// every rule that reads ARGS runs its transformations over each one, so a small
+// deeply-nested body can cost more than a large flat one. SecRequestBodyJsonDepthLimit
+// is what bounds that depth. That budget has no ModSecurity equivalent, is not governed by this
+// directive. Unlike an argument-count trip it is reported as a parse failure,
+// so it names itself in REQBODY_ERROR_MSG (RES_BODY_ERROR_MSG on the response
+// path), which contains "json decoded size limit exceeded" after the body
+// processor name. The leaves decoded before it tripped are still stored.
+//
 // Example:
 // ```apache
 // SecArgumentsLimit 1000

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -7,14 +7,11 @@ import (
 	"strings"
 )
 
-// ParseQuery parses the URL-encoded query string and returns the corresponding map.
-// It takes separators as parameter, for example: & or ; or &;
-func ParseQuery(query string, separator byte) map[string][]string {
-	return doParseQuery(query, separator, true)
-}
-
-func doParseQuery(query string, separator byte, urlUnescape bool) map[string][]string {
-	m := make(map[string][]string)
+// EachQueryValue scans the URL-encoded query string in document order and
+// calls f with each unescaped key/value pair. It takes separators as parameter,
+// for example: & or ; or &;. Scanning stops as soon as f returns false; pairs
+// past that point are never decoded.
+func EachQueryValue(query string, separator byte, f func(key, value string) bool) {
 	for query != "" {
 		key := query
 		if i := strings.IndexByte(key, separator); i >= 0 {
@@ -29,13 +26,12 @@ func doParseQuery(query string, separator byte, urlUnescape bool) map[string][]s
 		if i := strings.IndexByte(key, '='); i >= 0 {
 			key, value = key[:i], key[i+1:]
 		}
-		if urlUnescape {
-			key = queryUnescape(key)
-			value = queryUnescape(value)
+		key = queryUnescape(key)
+		value = queryUnescape(value)
+		if !f(key, value) {
+			return
 		}
-		m[key] = append(m[key], value)
 	}
-	return m
 }
 
 // queryUnescape is a non-strict version of net/url.QueryUnescape.

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -4,21 +4,26 @@
 package url
 
 import (
+	"reflect"
 	"testing"
 )
 
 var parseQueryInput = `var=EmptyValue'||(select extractvalue(xmltype('<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE root [ <!ENTITY % awpsd SYSTEM "http://0cddnr5evws01h2bfzn5zd0cm3sxvrjv7oufi4.example'||'foo.bar/">%awpsd;`
 
 func TestUrlPayloads(t *testing.T) {
-	q := ParseQuery(parseQueryInput, '&')
-	if len(q["var"]) == 0 {
+	values := map[string][]string{}
+	EachQueryValue(parseQueryInput, '&', func(key, value string) bool {
+		values[key] = append(values[key], value)
+		return true
+	})
+	if len(values["var"]) == 0 {
 		t.Error("var is empty")
 	}
 }
 
-func BenchmarkParseQuery(b *testing.B) {
+func BenchmarkEachQueryValue(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		ParseQuery(parseQueryInput, '&')
+		EachQueryValue(parseQueryInput, '&', func(key, value string) bool { return true })
 	}
 }
 
@@ -47,5 +52,19 @@ func BenchmarkQueryUnescape(b *testing.B) {
 		for k := range queryUnescapePayloads {
 			queryUnescape(k)
 		}
+	}
+}
+
+// TestEachQueryValueStopsOnFalse asserts that returning false from the callback
+// ends the walk. Callers rely on it to stop decoding at an argument limit, so
+// without it the remaining arguments are decoded and thrown away.
+func TestEachQueryValueStopsOnFalse(t *testing.T) {
+	var seen []string
+	EachQueryValue("a=1&b=2&c=3&d=4", '&', func(key, value string) bool {
+		seen = append(seen, key+"="+value)
+		return len(seen) < 2
+	})
+	if want, have := []string{"a=1", "b=2"}, seen; !reflect.DeepEqual(want, have) {
+		t.Errorf("walk did not stop on false, want %v, have %v", want, have)
 	}
 }

--- a/testing/engine/argumentslimit.go
+++ b/testing/engine/argumentslimit.go
@@ -1,0 +1,160 @@
+// Copyright 2026 CloudLinux
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import (
+	"github.com/corazawaf/coraza/v3/testing/profile"
+)
+
+var _ = profile.RegisterProfile(profile.Profile{
+	Meta: profile.Meta{
+		Author:      "quirky4",
+		Description: "Test that exceeding SecArgumentsLimit raises REQBODY_ERROR with the SecArgumentsLimit message and blocks",
+		Enabled:     true,
+		Name:        "argumentslimit.yaml",
+	},
+	Tests: []profile.Test{
+		{
+			// The payload sits in the trailing members, past the limit, so rule
+			// 4 must stay quiet: the arguments cut are the trailing ones and the
+			// attacker picks them.
+			Title: "arguments limit exceeded blocks and drops the tail",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI:    "/",
+							Method: "POST",
+							Headers: map[string]string{
+								"content-type": "application/json",
+							},
+							Data: `{"k0":"v","k1":"v","k2":"v","k3":"v","k4":"v","k5":"' OR 1=1--","k6":"' OR 1=1--","k7":"' OR 1=1--","k8":"' OR 1=1--","k9":"' OR 1=1--"}`,
+						},
+						Output: profile.ExpectedOutput{
+							TriggeredRules:    []int{1, 2},
+							NonTriggeredRules: []int{4},
+							Interruption: &profile.ExpectedInterruption{
+								Status: 400,
+								RuleID: 2,
+								Action: "deny",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// The same payload under the limit, so rule 4 is known to match it
+			// when the member really reaches inspection.
+			Title: "body payload within the limit is inspected",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI:    "/",
+							Method: "POST",
+							Headers: map[string]string{
+								"content-type": "application/json",
+							},
+							Data: `{"k0":"v","k1":"' OR 1=1--"}`,
+						},
+						Output: profile.ExpectedOutput{
+							TriggeredRules:    []int{4},
+							NonTriggeredRules: []int{1, 2},
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "arguments within limit pass",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI:    "/",
+							Method: "POST",
+							Headers: map[string]string{
+								"content-type": "application/json",
+							},
+							Data: `{"k0":"v","k1":"v","k2":"v"}`,
+						},
+						Output: profile.ExpectedOutput{
+							NonTriggeredRules: []int{1, 2, 4},
+						},
+					},
+				},
+			},
+		},
+		{
+			// The payload sits past the limit, so rule 4 must stay quiet: the
+			// arguments cut are the trailing ones and the attacker picks them.
+			Title: "query string over the limit blocks and drops the tail",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI:    "/?a=1&b=2&c=3&d=4&e=5&f=6&evil=%27+OR+1%3D1--+",
+							Method: "GET",
+						},
+						Output: profile.ExpectedOutput{
+							TriggeredRules:    []int{1, 2},
+							NonTriggeredRules: []int{4},
+							Interruption: &profile.ExpectedInterruption{
+								Status: 400,
+								RuleID: 2,
+								Action: "deny",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// The same payload under the limit, so rule 4 is known to match it
+			// when the argument really reaches inspection.
+			Title: "query string payload within the limit is inspected",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI:    "/?evil=%27+OR+1%3D1--+",
+							Method: "GET",
+						},
+						Output: profile.ExpectedOutput{
+							TriggeredRules:    []int{4},
+							NonTriggeredRules: []int{1, 2},
+						},
+					},
+				},
+			},
+		},
+		{
+			Title: "query string within the limit passes",
+			Stages: []profile.Stage{
+				{
+					Stage: profile.SubStage{
+						Input: profile.StageInput{
+							URI:    "/?a=1&b=2&c=3",
+							Method: "GET",
+						},
+						Output: profile.ExpectedOutput{
+							NonTriggeredRules: []int{1, 2, 4},
+						},
+					},
+				},
+			},
+		},
+	},
+	Rules: `
+SecRequestBodyAccess On
+SecArgumentsLimit 5
+SecAction "id:100, phase:1, pass, log, ctl:requestBodyProcessor=JSON"
+SecRule REQBODY_ERROR_MSG "@streq SecArgumentsLimit exceeded" "id:1, phase:2, pass, log"
+# Declared before the denying rule so it evaluates on the stages that block:
+# ARGS_POST is filled in phase 2, and rule 2 ends the transaction there.
+SecRule ARGS "@contains 1=1" "id:4, phase:2, pass, log"
+SecRule REQBODY_ERROR "!@eq 0" "id:2, phase:2, deny, status:400, log"
+`,
+})

--- a/testing/engine_test.go
+++ b/testing/engine_test.go
@@ -5,10 +5,12 @@ package testing
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/types"
 )
 
 func TestRawRequests(t *testing.T) {
@@ -100,4 +102,68 @@ func buildRequest(method, uri string) string {
 		method + " " + uri + " HTTP/1.1",
 		"Host: www.example.com",
 	}, "\r\n")
+}
+
+// TestRecommendedConfArgumentsLimit asserts that the REQBODY_ERROR rule
+// shipped in coraza.conf-recommended denies a request whose arguments were
+// only inspected in part, with the status the file declares, and stays quiet
+// on a request that fits under SecArgumentsLimit. The file is read from disk
+// so the rule that ships is the rule under test.
+func TestRecommendedConfArgumentsLimit(t *testing.T) {
+	const argumentsLimitRuleID = 200002
+
+	rec, err := os.ReadFile("../coraza.conf-recommended")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The file ships in DetectionOnly so that dropping it into a deployment
+	// cannot break traffic; blocking is what the rule is asserted on here.
+	waf, err := coraza.NewWAF(coraza.NewWAFConfig().
+		WithDirectives(string(rec)).
+		WithDirectives("SecRuleEngine On\nSecArgumentsLimit 5"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		uri  string
+		want *types.Interruption
+	}{
+		{
+			name: "over the limit",
+			uri:  "/?a=1&b=2&c=3&d=4&e=5&f=6&evil=1",
+			want: &types.Interruption{RuleID: argumentsLimitRuleID, Status: 400, Action: "deny"},
+		},
+		{
+			name: "under the limit",
+			uri:  "/?a=1&b=2&c=3",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tx := waf.NewTransaction()
+			defer func() {
+				if err := tx.Close(); err != nil {
+					t.Fatalf("Failed to close transaction: %s", err.Error())
+				}
+			}()
+			tx.ProcessURI(tc.uri, "GET", "HTTP/1.1")
+			tx.AddRequestHeader("Host", "www.example.com")
+			tx.ProcessRequestHeaders()
+			if _, err := tx.ProcessRequestBody(); err != nil {
+				t.Fatal(err)
+			}
+			have := tx.Interruption()
+			switch {
+			case tc.want == nil:
+				if have != nil {
+					t.Fatalf("a request under SecArgumentsLimit must not be interrupted, have %+v", have)
+				}
+			case have == nil:
+				t.Fatal("a request over SecArgumentsLimit was not interrupted")
+			case have.RuleID != tc.want.RuleID || have.Status != tc.want.Status || have.Action != tc.want.Action:
+				t.Fatalf("unexpected interruption, want %+v, have %+v", tc.want, have)
+			}
+		})
+	}
 }


### PR DESCRIPTION
# DEF-51539: enforce SecArgumentsLimit in body processors, plus two leaks

Three independent defects, one commit each. Each commit carries its implementation and its tests together, and each builds and passes the suite on its own.

| Commit | Fix |
|---|---|
| `9c12d00` | `SecArgumentsLimit` is enforced in the body processors (was query-string only) |
| `ff907d1` | `Close()` releases per-request references instead of holding them in the pool |
| `1bc9fc2` | `@rbl` no longer leaks a goroutine when a lookup outlives its timeout |

28 files, +3982 / −147.

---

## 1. `SecArgumentsLimit` in body processors (`9c12d00`)

**The defect.** `WAF.ArgumentLimit` was only ever checked on the query-string path. Every body processor flattened the entire decoded body into its collections through the raw setters, so a single request body with hundreds of thousands of members created that many live collection members regardless of the configured limit. Per-member rule transformations then multiplied the cost — a one-shot memory-exhaustion DoS.

**The fix.** `BodyProcessorOptions` gains an `ArgumentLimit`, populated from `WAF.ArgumentLimit` on both the request and response paths. Each processor fills its collections in document order up to a budget and then stops parsing, so no work is done for arguments that are discarded.

Budgets under the default limit of 1000:

| Collection | Budget | Notes |
|---|---|---|
| `ARGS_GET`, `ARGS_PATH`, `ARGS_POST`, `RESPONSE_ARGS` | 1000 | one member per stored value |
| `MULTIPART_PART_HEADERS` | 8000 | `limit × MaxHeadersPerPart`; exhausting it truncates without aborting the parse |
| `REQUEST_XML` | 16000 | `limit × MaxNodesPerArgument` |
| JSON array-length entries | 2000 | `limit × MaxEntriesPerArgument`; dropped silently when exhausted |
| JSON decoded bytes | `len(body) + min(len(body)×64, 1 MiB)` | no ModSecurity equivalent; bounds path-prefix amplification |

The wider budgets are not arbitrary — charging XML nodes or multipart part-headers one-for-one denied ordinary traffic (a 25 KB SOAP body of 334 records; a 501-field form). Each constant documents its own scale.

**Also in this commit, all reachable from the same root cause:**

- **`Map.Len()` counts stored values, not distinct keys.** Counting keys left the caps unbounded in practice: `?a=0&a=1&…` stores every value under one key and never reached the limit, so a 1.9 MB query string held 13 MB of live heap with no signal. This matches how ModSecurity counts one argument-table entry per `key=value` pair.
- **`RES_BODY_ERROR`, `RES_BODY_ERROR_MSG`, `RES_BODY_PROCESSOR_ERROR`, `RES_BODY_PROCESSOR_ERROR_MSG` were unreachable** — `Transaction.Collection()` had no cases for them, so a rule written against them could never match. Mapping them exposed a second bug: they were also missing from `TransactionVariables.All()`, which `reset()` walks, so one malformed response body would have permanently poisoned a pooled transaction. A structural test now asserts the general invariant.
- **Multipart temp files are registered in `FILES_TMP_NAMES` before any error return**, because transaction cleanup only removes what is listed there.

### Behaviour change operators will notice

**Requests that were previously accepted may now be denied.** Rule 200002 in `coraza.conf-recommended` already denies on `REQBODY_ERROR`, and a `SecArgumentsLimit` trip now sets it. That is the intended outcome, but it is a live behaviour change on any deployment running that rule — worth a staged rollout rather than a straight upgrade.

Truncation is signalled exactly as ModSecurity v2 signals it: `REQBODY_ERROR=1` and `REQBODY_ERROR_MSG="SecArgumentsLimit exceeded"`, the literal string from `add_argument()` in `apache2/msc_parsers.c`. The response side uses `RES_BODY_ERROR` / `RES_BODY_ERROR_MSG`. **No new rule and no new variable ships** — a fork-local variable was built first and reversed, because an unknown variable is a fatal config error rather than a skipped rule on both ModSecurity v2 and v3, and this rule corpus is shared across the Apache, LiteSpeed, nginx and Coraza bundles.

`coraza.conf-recommended` changes are limited to a comment above rule 200002 explaining that truncation also fires it, and how to tell the two causes apart via `REQBODY_ERROR_MSG`.

## 2. `Close()` releases per-request references (`ff907d1`)

Transactions are recycled through a `sync.Pool`. `Close()` left matched rules, the transformation cache, and the request context reachable, so a pooled transaction held that memory until its next use.

## 3. `@rbl` goroutine leak (`1bc9fc2`)

A DNS lookup that outlived its timeout left its goroutine blocked forever on an unbuffered channel send, and could touch the transaction after it had been recycled. The channel is now buffered, the context is cancelled, and the goroutine no longer captures the transaction.

---

## Verification

- `go build`, `go vet`, `go test ./...`
- `go test ./... -count=3 -race -shuffle=on`
- Build tags: `coraza.rule.multiphase_evaluation`, `no_fs_access`, `coraza.no_memoize`, `coraza.disabled_operators.rbl`
- `go build -tags tinygo`; full suite under `GOARCH=386`
- `mage lint` → 0 issues
- Each commit verified to build and pass independently

Six review rounds. Every behavioural guarantee added here is mutation-tested — the source is deliberately broken and the suite confirmed to fail — because several defects found during review were in tests that could not detect violation of the guarantee they were named for.

## Known limitations

Deliberately not fixed here; each is recorded rather than left to be rediscovered.

- **The JSON decoded-bytes budget bounds what is stored, not what inspecting it costs.** A body nested deeply enough spends its budget on long flattened paths, and every `ARGS` rule runs its transformations over each one. This is bounded, not eliminated: a 16 KiB body sized to the budget still costs roughly 158 ms of phase-2 CPU against 8.7 ms for a legitimate body of that size, with no error raised. A real fix needs a budget on accumulated key length rather than one derived from body length — a larger change than this should carry. `SecRequestBodyJsonDepthLimit` is the operator-side mitigation.
- **`SecRequestBodyJsonDepthLimit` above ~129 is inert for bare array nesting**, because the decoded-bytes budget stops it first. A documented-limit-vs-actual mismatch.
- **The limit is per-collection; ModSecurity's is global.** v2 keeps one `msr->arguments` table shared by query string, path and body, so 999 query args plus 999 POST fields trips nothing here where v2 blocks at 1000 total.
- **`REQUEST_COOKIES` is not capped.** ModSecurity v2 parses cookies into a separate table that never reaches `add_argument`, so capping them would diverge from the compatibility target; the vector is bounded by the front end's header limit.

## Review notes

Worth a closer look:

- `internal/collections/map.go` — the `valueCount` bookkeeping. `Len()` is not part of the public `collection.Map` interface, and the only two in-repo callers are deliberate, but every mutator has to maintain it correctly.
- `internal/bodyprocessors/json.go` — the two budgets and the drop-versus-fail decision for array-length entries. Failing on those denied bodies that carry no arguments at all; nothing portable can read a dropped entry, since neither ModSecurity version records an array length.
- `internal/seclang/directives.go` — `directiveSecArgumentsLimit` is the canonical documentation site for all of the above.