### PR TITLE
fix: parse XML bodies whose elements are named after HTML void elements

### DIFF
--- a/internal/bodyprocessors/argumentslimit_test.go
+++ b/internal/bodyprocessors/argumentslimit_test.go
@@ -212,8 +212,10 @@ func TestXMLArgumentsLimitSharedBudget(t *testing.T) {
 
 // TestXMLOrdinaryDocumentsAccepted asserts that documents an ordinary client
 // sends parse whole at the shipped default limit: a SOAP response of several
-// hundred records and a configuration document of several hundred elements
-// both hold more nodes than there are arguments in the budget.
+// hundred records, a configuration document of several hundred elements and an
+// XML-RPC multicall of several hundred parameters all hold more nodes than
+// there are arguments in the budget. Reaching ProcessRequest without an error
+// is what keeps REQUEST_XML populated and REQBODY_ERROR clear.
 func TestXMLOrdinaryDocumentsAccepted(t *testing.T) {
 	bp, err := bodyprocessors.GetBodyProcessor("xml")
 	if err != nil {
@@ -233,12 +235,20 @@ func TestXMLOrdinaryDocumentsAccepted(t *testing.T) {
 	}
 	config.WriteString("</configuration>")
 
+	xmlrpc := strings.Builder{}
+	xmlrpc.WriteString(`<?xml version="1.0"?><methodCall><methodName>system.multicall</methodName><params>`)
+	for i := 0; i < 300; i++ {
+		fmt.Fprintf(&xmlrpc, `<param><value><string>value %d</string></value></param>`, i)
+	}
+	xmlrpc.WriteString(`</params></methodCall>`)
+
 	for _, tc := range []struct {
 		name string
 		body string
 	}{
 		{name: "soap_records", body: soap.String()},
 		{name: "config_elements", body: config.String()},
+		{name: "xmlrpc_multicall", body: xmlrpc.String()},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			v := corazawaf.NewTransactionVariables(persistence.NoopEngine{})

--- a/internal/bodyprocessors/xml.go
+++ b/internal/bodyprocessors/xml.go
@@ -50,8 +50,14 @@ func readXML(reader io.Reader, limit int) ([]string, []string, error) {
 	var attrs []string
 	var content []string
 	dec := xml.NewDecoder(reader)
+	// Strict false is what lets an element be closed by an ancestor's end tag
+	// rather than its own, so an unterminated element costs only itself; a body
+	// cut short is tolerated separately, by the unexpected EOF branch below.
+	// AutoClose stays unset: it self-closes the elements on Go's HTML void list,
+	// and param, link, input and col are ordinary container elements in XML-RPC,
+	// Atom and SOAP bodies, whose real end tag would then abort decoding as
+	// unexpected.
 	dec.Strict = false
-	dec.AutoClose = xml.HTMLAutoClose
 	dec.Entity = xml.HTMLEntity
 	for {
 		token, err := dec.Token()

--- a/internal/bodyprocessors/xml_test.go
+++ b/internal/bodyprocessors/xml_test.go
@@ -69,6 +69,75 @@ func TestXMLPayloadFlexibility(t *testing.T) {
 	}
 }
 
+// Elements named after HTML void elements are ordinary containers in XML
+// vocabularies, and their end tag must not abort decoding.
+func TestXMLHTMLVoidElementNames(t *testing.T) {
+	testCases := []struct {
+		Name  string
+		Input string
+		Want  []string
+	}{
+		{
+			Name: "xmlRPCGetUsersBlogs",
+			Input: `<?xml version="1.0"?>
+			<methodCall>
+			  <methodName>wp.getUsersBlogs</methodName>
+			  <params>
+				<param><value><string>admin</string></value></param>
+				<param><value><string>hunter2</string></value></param>
+			  </params>
+			</methodCall>`,
+			Want: []string{"wp.getUsersBlogs", "admin", "hunter2"},
+		},
+		{
+			Name: "xmlRPCMulticall",
+			Input: `<?xml version="1.0"?>
+			<methodCall>
+			  <methodName>system.multicall</methodName>
+			  <params><param><value><array><data>
+				<value><struct>
+				  <member><name>methodName</name><value><string>wp.getCategories</string></value></member>
+				</struct></value>
+			  </data></array></value></param></params>
+			</methodCall>`,
+			Want: []string{"system.multicall", "methodName", "wp.getCategories"},
+		},
+		{
+			Name:  "atomLink",
+			Input: `<entry><link href="https://example.com">alternate</link></entry>`,
+			Want:  []string{"alternate"},
+		},
+		{
+			// Elements left unterminated still decode, so leniency for
+			// unbalanced documents does not depend on self-closing them.
+			Name:  "unterminatedParam",
+			Input: `<methodCall><params><param><value>admin</value></params></methodCall>`,
+			Want:  []string{"admin"},
+		},
+		{
+			Name:  "unterminatedHTMLVoidElements",
+			Input: `<html><body>before<br>after<img src="x"></body></html>`,
+			Want:  []string{"before", "after"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, contents, err := readXML(bytes.NewReader([]byte(tc.Input)), 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(contents), len(tc.Want); got != want {
+				t.Fatalf("contents count mismatch, got=%d (%v), want=%d", got, contents, want)
+			}
+			for i := range contents {
+				if got, want := contents[i], tc.Want[i]; got != want {
+					t.Errorf("Expected content got=%s, want=%s", got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestXMLUnexpectedEOF(t *testing.T) {
 	testCases := []struct {
 		Name  string


### PR DESCRIPTION
Fixes DEF-51266.

### Problem

The XML request-body decoder ran with `dec.AutoClose = xml.HTMLAutoClose`, which
self-closes every element on Go's HTML void list — including `param`, `link`,
`input` and `col`. Those are ordinary *container* elements in XML-RPC, Atom and
SOAP, so once the decoder invented their end tag, the document's real end tag
arrived as a stray one and decoding aborted:

XML syntax error on line 5: unexpected end element </param>

`ProcessRequest` returned that error before reaching `col.Set`, so `REQUEST_XML`
stayed empty and `REQBODY_ERROR` was set. Every rule keyed on XML variables
matched nothing: XML-RPC brute-force, pingback and multicall-amplification
detection (77317950/51, 77350179/81, 77317980, 77231011) fired ~0 times on the
Coraza fleet against millions on Apache/LiteSpeed, and the XMLRpcBruteforce
captcha and www-brute RBL blocking downstream never triggered. In practice this
means essentially **every WordPress `xmlrpc.php` call was uninspected**.

### Fix

Remove the one line. `Strict = false` and `Entity = xml.HTMLEntity` are unchanged.

### Does this reduce the leniency PR #622 added?

No — it strictly increases it. This is the main thing worth reviewing, since the
line was added deliberately to be lenient with malformed payloads.

`readXML` collects attribute values off `StartElement` and text off `CharData`.
It never inspects `EndElement` and never builds a tree, so self-closing an
element cannot change any member it collects. `AutoClose`'s only observable
effect here was on the error path — and `Strict = false` does not forgive a
stray end tag, because it invents *missing* end tags rather than tolerating
extra ones.

The flexibility for malformed payloads rests on two mechanisms this PR does not
touch: `Strict = false` lets an unterminated element be closed by an ancestor's
end tag, and the `unexpected EOF` branch tolerates a body cut short.

Measured over 738 payloads (hand-written malformed/HTML-shaped bodies plus
deterministic mutations — truncations, byte deletions, injected `<br>`), parsed
both with and without `AutoClose`:

| | |
|---|---|
| Payloads that lost an attribute or text node | **0** |
| Payloads that gained members | 50 |
| Byte-identical output | 688 |
| Parse failures with `AutoClose` | 316 |
| Parse failures without | **281** |

### Testing

- `TestXMLHTMLVoidElementNames` — XML-RPC `wp.getUsersBlogs` and
  `system.multicall`, Atom `<link>`, plus two rows pinning that unterminated
  void elements still decode (the invariant the fix relies on).
- One `xmlrpc_multicall` row added to the existing `TestXMLOrdinaryDocumentsAccepted`
  table, which goes through `ProcessRequest` — the bug was that
  `ProcessRequest` returned *before* populating, which a `readXML`-level test
  cannot catch.
- Mutation-tested: restoring `AutoClose` fails all four regression cases, the
  collection-level one reporting `rejected a 16794 byte document holding 0
  members` — the ticket's symptom verbatim.
- Full suite, `go vet` and `gofmt` clean.

### Out of scope

The `XML://methodName/text()` XPath selectors the rules would rather key on are
still unsupported (only `//@*` and `/*` keys exist) — this is the engine half
only; the rule-side rewrite is a separate WPT item, upstream
[#1322](https://github.com/corazawaf/coraza/issues/1322).

### Upstream

- Still unfixed at `corazawaf/coraza` HEAD; no open upstream PR touches
  `internal/bodyprocessors/xml.go`.
- [#1441](https://github.com/corazawaf/coraza/issues/1441) reports this exact
  bug with the same `wp.getUsersBlogs` payload, but the root cause was never
  identified there — `AutoClose` is mentioned nowhere upstream (no issue, PR or
  discussion). Reporters work around it by disabling CRS rules 200000/200002.
- [#622](https://github.com/corazawaf/coraza/pull/622) introduced the line to
  add "flexible XML body processing for malformed payloads", with no test
  exercising it.
- [#1452](https://github.com/corazawaf/coraza/pull/1452), in this fork since
  `f18e237`, added `unexpected EOF` tolerance but does not cover `unexpected
  end element`.

An upstream PR and a root-cause comment on #1441 are follow-ups.