### PR TITLE
fix: query RBL zones with the operand verbatim (DEF-52893, DEF-52371)

### DIFF
--- a/internal/operators/rbl.go
+++ b/internal/operators/rbl.go
@@ -8,8 +8,8 @@ package operators
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/corazawaf/coraza/v3/experimental/plugins/plugintypes"
@@ -18,23 +18,26 @@ import (
 const timeout = 500 * time.Millisecond
 
 // Description:
-// Looks up the input IP address in the specified RBL (Real-time Block List) service.
-// Performs DNS lookups to check if the IP is listed. Sets TX.httpbl_msg variable with
-// the response text if found. Has a 500ms timeout for DNS queries.
+// Looks up the operand in the specified RBL (Real-time Block List) zone.
+// The operand becomes the query label verbatim, so it may be an IP address
+// or any other key a zone is published under, such as a SHA-1 hex digest.
+// Sets TX.httpbl_msg to the zone's TXT reason when one exists. Has a 500ms
+// timeout for DNS queries.
 //
 // Arguments:
-// RBL hostname to query (e.g., "sbl-xbl.spamhaus.org").
+// RBL zone to query (e.g., "pswd.rbl.imunify.com.").
 //
 // Returns:
-// true if the IP address is found in the RBL, false otherwise or on timeout
+// true if the operand is listed — the zone answers with a listing code
+// inside 127.0.0.0/8 — false otherwise or on lookup failure
 //
 // Example:
 // ```
-// # Check IP against Spamhaus blocklist
-// SecRule REMOTE_ADDR "@rbl sbl-xbl.spamhaus.org" "id:183,deny,log,msg:'IP found in RBL'"
+// # Check the client address against a regular-order blocklist
+// SecRule TX:rbl_ip "@rbl www-brute.v2.rbl.imunify.com." "id:183,deny,log,msg:'IP found in RBL'"
 //
-// # Multiple RBL checks
-// SecRule REMOTE_ADDR "@rbl dnsbl.example.com" "id:184,deny"
+// # Check a hashed credential against a hash-keyed zone
+// SecRule TX:weak_pwd "@rbl pswd.rbl.imunify.com." "id:184,deny"
 // ```
 type rbl struct {
 	service  string
@@ -45,6 +48,11 @@ var _ plugintypes.Operator = (*rbl)(nil)
 
 func newRBL(options plugintypes.OperatorOptions) (plugintypes.Operator, error) {
 	data := options.Arguments
+	if data == "" {
+		// Without a zone every lookup goes to the DNS root and no operand can
+		// ever be listed, so the rule would load as enforcement that is inert.
+		return nil, errors.New("missing RBL service hostname")
+	}
 
 	return &rbl{
 		service:  data,
@@ -52,12 +60,10 @@ func newRBL(options plugintypes.OperatorOptions) (plugintypes.Operator, error) {
 	}, nil
 }
 
-// https://github.com/mrichman/godnsbl
-// https://github.com/SpiderLabs/ModSecurity/blob/b66224853b4e9d30e0a44d16b29d5ed3842a6b11/src/operators/rbl.cc
-func (o *rbl) Evaluate(tx plugintypes.TransactionState, ipAddr string) bool {
-	if net.ParseIP(ipAddr) == nil {
-		// The operand is unvalidated request data, so it stays out of the message.
-		tx.DebugLogger().Warn().Msg("RBL lookup skipped: operand is not an IP address")
+// https://github.com/owasp-modsecurity/ModSecurity/blob/b66224853b4e9d30e0a44d16b29d5ed3842a6b11/apache2/re_operators.c (msre_op_rbl_execute)
+func (o *rbl) Evaluate(tx plugintypes.TransactionState, operand string) bool {
+	if operand == "" {
+		tx.DebugLogger().Debug().Msg("RBL lookup skipped: empty operand")
 		return false
 	}
 
@@ -66,29 +72,75 @@ func (o *rbl) Evaluate(tx plugintypes.TransactionState, ipAddr string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	addr := fmt.Sprintf("%s.%s", ipAddr, o.service)
+	// The query name is the operand written in front of the zone, verbatim.
+	// Blocklists disagree on the key form — public RFC 5782 zones expect
+	// reversed IPv4 octets, while the Imunify zones queried in production
+	// (rbl.imunify.com) are keyed by regular-order addresses and SHA-1
+	// hashes — so the operand passes through untouched and each rule
+	// supplies the key in the form its zone expects. ModSecurity sends every
+	// operand that is not a bare IPv4 address the same way, and the Imunify
+	// ruleset feeds all engines operands of exactly that shape. An operand
+	// no zone can list — an IPv6 address, junk request data — fails the
+	// lookup and is reported unlisted.
+	addr := operand + "." + o.service
+	// LookupIP and LookupNetIP would undo the deadline: they go through the
+	// shared lookup group in net, where concurrent lookups of one name join a
+	// single call that stops being cancellable as soon as it has a second
+	// waiter and then outlives all of them, so a slow blocklist would pin a
+	// goroutine per request.
 	res, err := o.resolver.LookupHost(ctx, addr)
 	if err != nil {
 		logRBLLookupError(tx, addr, err)
 		return false
 	}
+	if !anyListingCode(res) {
+		tx.DebugLogger().Warn().
+			Str("address", addr).
+			Str("answers", strings.Join(res, " ")).
+			Msg("RBL answer is not a listing code, treating operand as not listed")
+		return false
+	}
 
-	var status string
-	if len(res) > 0 {
-		txt, err := o.resolver.LookupTXT(ctx, addr)
-		if err != nil {
-			logRBLLookupError(tx, addr, err)
-			return false
-		}
-		if len(txt) > 0 {
-			status = txt[0]
-		}
+	// The address record alone decides that the operand is listed. The TXT
+	// record only carries the human-readable reason, so a zone that publishes
+	// none — or a TXT lookup that fails on its own — must not undo the
+	// verdict.
+	var reason string
+	if txt, err := o.resolver.LookupTXT(ctx, addr); err != nil {
+		// The address lookup that just succeeded proves the resolver answers,
+		// so a failure here is almost always a zone with no TXT record, and it
+		// costs nothing: the verdict is already settled.
+		tx.DebugLogger().Debug().Err(err).Str("address", addr).Msg("RBL reason lookup failed")
+	} else if len(txt) > 0 {
+		reason = txt[0]
 	}
-	if status != "" {
-		tx.Variables().TX().Set("httpbl_msg", []string{status})
-		tx.CaptureField(0, status)
+	// Whatever the reason turns out to be, it has to describe this match: a
+	// zone that publishes no TXT record must not leave an earlier RBL rule's
+	// message standing as if it belonged here.
+	if reason == "" {
+		tx.Variables().TX().Remove("httpbl_msg")
+	} else {
+		tx.Variables().TX().Set("httpbl_msg", []string{reason})
 	}
+	tx.CaptureField(0, reason)
 	return true
+}
+
+// anyListingCode reports whether an answer means the operand asked about is
+// listed. RFC 5782 §2.1 puts a listing in 127.0.0.0/8, and zones answer in the
+// top of that block, 127.255.255.0/24, to complain about the query itself — a
+// public resolver, an exhausted quota — which says nothing about the operand.
+// A resolver that invents an address for every name it cannot resolve answers
+// outside 127.0.0.0/8 altogether. Reading either as a listing would block
+// every request.
+func anyListingCode(answers []string) bool {
+	for _, answer := range answers {
+		v4 := net.ParseIP(answer).To4()
+		if v4 != nil && v4[0] == 127 && (v4[1] != 255 || v4[2] != 255) {
+			return true
+		}
+	}
+	return false
 }
 
 // logRBLLookupError reports a failed lookup at the level its cause deserves. A
@@ -102,7 +154,7 @@ func logRBLLookupError(tx plugintypes.TransactionState, addr string, err error) 
 	case errors.As(err, &dnsErr) && dnsErr.IsNotFound:
 		tx.DebugLogger().Debug().Str("address", addr).Msg("RBL record not found")
 	case errors.Is(err, context.DeadlineExceeded), errors.As(err, &dnsErr) && dnsErr.IsTimeout:
-		tx.DebugLogger().Warn().Str("address", addr).Msg("RBL lookup timed out, treating IP as not listed")
+		tx.DebugLogger().Warn().Str("address", addr).Msg("RBL lookup timed out, treating operand as not listed")
 	case errors.Is(err, context.Canceled):
 		tx.DebugLogger().Debug().Str("address", addr).Msg("RBL lookup cancelled")
 	default:

--- a/internal/operators/rbl_test.go
+++ b/internal/operators/rbl_test.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,7 +30,7 @@ func (l *testLogger) Printf(format string, v ...any) {
 
 func TestRbl(t *testing.T) {
 	opts := plugintypes.OperatorOptions{
-		Arguments: "xbl.spamhaus.org",
+		Arguments: "rbl.example.com",
 	}
 	op, err := newRBL(opts)
 	if err != nil {
@@ -40,17 +39,35 @@ func TestRbl(t *testing.T) {
 
 	logger := &testLogger{t}
 
+	// Zone entries are keyed by the operand as written — regular-order
+	// addresses and hash digests, the forms the Imunify zones publish.
 	srv, err := mockdns.NewServerWithLogger(map[string]mockdns.Zone{
-		"1.1.1.1.xbl.spamhaus.org.": {
-			A: []string{"1.2.3.4"},
-		},
-		"1.1.1.2.xbl.spamhaus.org.": {
-			A:   []string{"1.2.3.5"},
-			TXT: []string{"not blocked"},
-		},
-		"1.1.1.3.xbl.spamhaus.org.": {
-			A:   []string{"1.2.3.6"},
+		"1.2.3.4.rbl.example.com.": {
+			A:   []string{"127.0.0.2"},
 			TXT: []string{"blocked"},
+		},
+		"1.2.3.5.rbl.example.com.": {
+			A: []string{"127.0.0.2"},
+		},
+		"e0c4ccdf99f5c5aa1e02930026a4c0db4d62c348.rbl.example.com.": {
+			A:   []string{"127.0.0.1"},
+			TXT: []string{"Weak password"},
+		},
+		// 1.2.3.6 is listed only under its reversed name, so a match for it
+		// means the operator rewrote the operand instead of passing it
+		// through.
+		"6.3.2.1.rbl.example.com.": {
+			A:   []string{"127.0.0.2"},
+			TXT: []string{"reversed"},
+		},
+		// 3.4.5.6 gets the answer a resolver that invents addresses for names
+		// it cannot resolve would give, and 4.4.5.6 the code a zone answers
+		// with when it objects to the query rather than the operand.
+		"3.4.5.6.rbl.example.com.": {
+			A: []string{"203.0.113.9"},
+		},
+		"4.4.5.6.rbl.example.com.": {
+			A: []string{"127.255.255.254"},
 		},
 	}, logger, false)
 	if err != nil {
@@ -61,20 +78,33 @@ func TestRbl(t *testing.T) {
 	srv.PatchNet(op.(*rbl).resolver)
 	defer mockdns.UnpatchNet(op.(*rbl).resolver)
 
-	t.Run("IP with an A record but no TXT record is not reported listed", func(t *testing.T) {
+	t.Run("Listed IP with TXT record", func(t *testing.T) {
 		tx := corazawaf.NewWAF().NewTransaction()
-		if op.Evaluate(tx, "1.1.1.1") {
-			t.Errorf("an A record without a TXT record must not report the IP as listed")
+		if !op.Evaluate(tx, "1.2.3.4") {
+			t.Fatal("Unexpected result for listed IP")
+		}
+		if want, have := "blocked", tx.Variables().TX().Get("httpbl_msg")[0]; want != have {
+			t.Errorf("Unexpected result for listed IP: want %q, have %q", want, have)
 		}
 	})
 
-	t.Run("Listed IP with TXT record", func(t *testing.T) {
+	t.Run("Listed IP without TXT record", func(t *testing.T) {
 		tx := corazawaf.NewWAF().NewTransaction()
-		if !op.Evaluate(tx, "1.1.1.2") {
-			t.Errorf("Unexpected result for listed IP")
+		if !op.Evaluate(tx, "1.2.3.5") {
+			t.Error("a listed IP whose zone publishes no TXT record must still be reported listed")
 		}
-		if want, have := "not blocked", tx.Variables().TX().Get("httpbl_msg")[0]; want != have {
-			t.Errorf("Unexpected result for listed IP: want %q, have %q", want, have)
+		if got := tx.Variables().TX().Get("httpbl_msg"); len(got) > 0 {
+			t.Errorf("httpbl_msg set without a TXT record: %q", got)
+		}
+	})
+
+	t.Run("Listed hash operand", func(t *testing.T) {
+		tx := corazawaf.NewWAF().NewTransaction()
+		if !op.Evaluate(tx, "e0c4ccdf99f5c5aa1e02930026a4c0db4d62c348") {
+			t.Fatal("a hash operand listed in a hash-keyed zone must be reported listed")
+		}
+		if want, have := "Weak password", tx.Variables().TX().Get("httpbl_msg")[0]; want != have {
+			t.Errorf("Unexpected reason for listed hash operand: want %q, have %q", want, have)
 		}
 	})
 
@@ -88,15 +118,59 @@ func TestRbl(t *testing.T) {
 		}
 	})
 
-	t.Run("Blocked IP", func(t *testing.T) {
+	t.Run("IP listed only under its reversed name", func(t *testing.T) {
 		tx := corazawaf.NewWAF().NewTransaction()
-		if !op.Evaluate(tx, "1.1.1.3") {
-			t.Fatal("Unexpected result for blocked IP")
-		}
-		if want, have := "blocked", tx.Variables().TX().Get("httpbl_msg")[0]; want != have {
-			t.Errorf("Unexpected result for blocked IP: want %q, have %q", want, have)
+		if op.Evaluate(tx, "1.2.3.6") {
+			t.Error("the operator rewrote the operand instead of querying it verbatim")
 		}
 	})
+
+	t.Run("IPv6 operand", func(t *testing.T) {
+		tx := corazawaf.NewWAF().NewTransaction()
+		if op.Evaluate(tx, "2001:db8::1") {
+			t.Error("an IPv6 operand must be reported unlisted: no zone publishes a name its colons can form")
+		}
+	})
+
+	t.Run("Empty operand", func(t *testing.T) {
+		tx := corazawaf.NewWAF().NewTransaction()
+		if op.Evaluate(tx, "") {
+			t.Error("Unexpected result for empty operand")
+		}
+	})
+
+	t.Run("Answer outside the listing range", func(t *testing.T) {
+		tx := corazawaf.NewWAF().NewTransaction()
+		if op.Evaluate(tx, "3.4.5.6") {
+			t.Error("an answer outside 127.0.0.0/8 must not be read as a listing")
+		}
+	})
+
+	t.Run("Answer complaining about the query", func(t *testing.T) {
+		tx := corazawaf.NewWAF().NewTransaction()
+		if op.Evaluate(tx, "4.4.5.6") {
+			t.Error("an answer in 127.255.255.0/24 must not be read as a listing")
+		}
+	})
+
+	t.Run("Reason of an earlier match does not survive", func(t *testing.T) {
+		tx := corazawaf.NewWAF().NewTransaction()
+		if !op.Evaluate(tx, "1.2.3.4") {
+			t.Fatal("Unexpected result for listed IP")
+		}
+		if !op.Evaluate(tx, "1.2.3.5") {
+			t.Fatal("Unexpected result for listed IP without a TXT record")
+		}
+		if got := tx.Variables().TX().Get("httpbl_msg"); len(got) > 0 {
+			t.Errorf("httpbl_msg still holds the earlier match's reason: %q", got)
+		}
+	})
+}
+
+func TestRblRequiresAService(t *testing.T) {
+	if _, err := newRBL(plugintypes.OperatorOptions{}); err == nil {
+		t.Error("an @rbl rule with no service hostname must not load")
+	}
 }
 
 // errorCapturingWAF returns a WAF whose debug logger records, at Error level
@@ -122,7 +196,7 @@ func errorCapturingWAF() (*corazawaf.WAF, func() []string) {
 
 func TestRblUnlistedIPDoesNotLogError(t *testing.T) {
 	opts := plugintypes.OperatorOptions{
-		Arguments: "xbl.spamhaus.org",
+		Arguments: "rbl.example.com",
 	}
 	op, err := newRBL(opts)
 	if err != nil {
@@ -147,24 +221,34 @@ func TestRblUnlistedIPDoesNotLogError(t *testing.T) {
 	}
 }
 
-func TestRblInvalidIPSkipsLookup(t *testing.T) {
-	var dialed atomic.Bool
-	op := &rbl{
-		service: "xbl.spamhaus.org",
-		resolver: &net.Resolver{
-			PreferGo: true,
-			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-				dialed.Store(true)
-				return nil, context.Canceled
-			},
-		},
+func TestRblIPv6OperandDoesNotLogError(t *testing.T) {
+	opts := plugintypes.OperatorOptions{
+		Arguments: "rbl.example.com",
 	}
-	tx := corazawaf.NewWAF().NewTransaction()
-	if op.Evaluate(tx, "not-an-ip") {
-		t.Error("Unexpected result for non-IP input")
+	op, err := newRBL(opts)
+	if err != nil {
+		t.Fatal("Cannot init rbl operator")
 	}
-	if dialed.Load() {
-		t.Error("Resolver was invoked for non-IP input")
+
+	srv, err := mockdns.NewServerWithLogger(map[string]mockdns.Zone{}, &testLogger{t}, false)
+	if err != nil {
+		t.Fatalf("Cannot start mockdns server: %v", err)
+	}
+	defer srv.Close()
+	srv.PatchNet(op.(*rbl).resolver)
+	defer mockdns.UnpatchNet(op.(*rbl).resolver)
+
+	// The colon-bearing name an IPv6 operand forms cannot exist in any zone,
+	// so it must fail as the ordinary negative answer: unlisted, and nothing
+	// above debug level — an IPv6 client would otherwise write one error
+	// line per request.
+	waf, capturedErrors := errorCapturingWAF()
+	tx := waf.NewTransaction()
+	if op.Evaluate(tx, "2001:db8::1") {
+		t.Error("Unexpected result for IPv6 operand")
+	}
+	if lines := capturedErrors(); len(lines) > 0 {
+		t.Errorf("IPv6 operand produced error-level log lines: %q", lines)
 	}
 }
 
@@ -181,7 +265,7 @@ func hangingResolver() *net.Resolver {
 }
 
 func TestRblTimeout(t *testing.T) {
-	op := &rbl{service: "xbl.spamhaus.org", resolver: hangingResolver()}
+	op := &rbl{service: "rbl.example.com", resolver: hangingResolver()}
 	tx := corazawaf.NewWAF().NewTransaction()
 
 	start := time.Now()
@@ -228,7 +312,7 @@ func waitForGoroutineBaseline(t *testing.T, baseline, slack int, deadline time.D
 }
 
 func TestRblTimeoutDoesNotLeakGoroutines(t *testing.T) {
-	op := &rbl{service: "xbl.spamhaus.org", resolver: hangingResolver()}
+	op := &rbl{service: "rbl.example.com", resolver: hangingResolver()}
 
 	before := stableGoroutineCount(t)
 
@@ -254,7 +338,7 @@ func TestRblTimeoutDoesNotLeakGoroutines(t *testing.T) {
 
 func TestRblCancelledLookupDoesNotLogError(t *testing.T) {
 	op := &rbl{
-		service: "xbl.spamhaus.org",
+		service: "rbl.example.com",
 		resolver: &net.Resolver{
 			PreferGo: true,
 			Dial: func(context.Context, string, string) (net.Conn, error) {
@@ -274,7 +358,7 @@ func TestRblCancelledLookupDoesNotLogError(t *testing.T) {
 }
 
 func TestRblTimeoutLeavesTransactionUntouched(t *testing.T) {
-	op := &rbl{service: "xbl.spamhaus.org", resolver: hangingResolver()}
+	op := &rbl{service: "rbl.example.com", resolver: hangingResolver()}
 
 	waf, capturedErrors := errorCapturingWAF()
 	tx := waf.NewTransaction()


### PR DESCRIPTION
## What

Restores verbatim `@rbl` query-name construction — `operand + "." + zone` — for **all** operands, and carries forward the answer-side hardening from the DEF-52371 work.

- **Fixes [DEF-52893](https://cloudlinux.atlassian.net/browse/DEF-52893)** (beta 1.47.0 regression): the `net.ParseIP` guard rejected the SHA-1 hash operands used by the weak-password (`pswd.rbl.imunify.com`, rules 33355/33357) and compromised-user (`wp-compromised.v2.rbl.imunify.com`) rules, silently disabling `cms_account_compromise_prevention` on Coraza stacks.
- **Withdraws the octet-reversal fix from [DEF-52371](https://cloudlinux.atlassian.net/browse/DEF-52371)**: `rbl.imunify.com`'s `*.v2` zones are keyed by *regular-order* wildcard entries (`.1.2.3.4` — defence360 `src/smart-block/fetch_ips.py`, DEF-10165). Every engine is steered to query them verbatim — apache/litespeed/modsec3 via the `%{TIME_HOUR}-%{TIME_MIN}.` prefix in rule 33368 (which routes ModSecurity's `@rbl` down its non-IP verbatim path), coraza via a plain operand because this operator has always been verbatim. Reversing here would have unlisted every address in production. Supersedes the `def-52371-rbl-reversed-lookup` branch.
- **Keeps from DEF-52371** (all verified compatible with the live service, which answers `127.0.0.1`): listing-code validation (127.0.0.0/8 minus 127.255.255.0/24 — this now carries the resolver-hijack protection), address-record-decides / TXT-only-annotates, `httpbl_msg` cleared when no reason exists, missing-service configuration error, `LookupHost`-with-deadline rationale.
- **IPv6**: unsupported end to end on every engine (ModSecurity has no IPv6 path; the service publishes no queryable IPv6 key). The colon-bearing name fails as an ordinary not-found → unlisted, debug level. A test pins this as chosen behavior.

## Test plan

- `go test ./internal/operators/` — fixtures moved to regular-order names; new cases: hash operand (real production shape, sha1 of `cRaUw_1$w_ppassword` → TXT `Weak password`), anti-reversal (entry listed only under the reversed name must **not** match), IPv6 operand (unlisted, no error-level log), empty operand.
- Verified against the live service: `dig e0c4ccdf….pswd.rbl.imunify.com` → `127.0.0.1` / TXT `"Weak password"`.

## Follow-ups (not this PR)

- Ruleset: unify coraza's rule 33368 onto the `HH-MM.` prefix variant; only after that, ModSec-v2 per-operand semantics (IP → reversed) become safe if public-DNSBL support is ever wanted.
- `good-bots.rbl.imunify.com` (the one v1/reversed zone in the ruleset) is dead on **all** engines — needs a ruleset-team ticket.
- defence360: MR 2341 adds the missing `webshield` mark to the weak-password rpm-test; `test_cpanel_password_reset.py` needs the same audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)